### PR TITLE
Quarkus 3.8.5 LTS

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
+            <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.temporal</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.13.0</quarkus.version>
+        <quarkus.version>3.8.5</quarkus.version>
         <temporal.version>1.24.3</temporal.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
This makes the extension available to a bigger range of people. Most plugins try and stay on an LTS version.