### PR TITLE
Allow IT to be run in `quarkus:dev` and kicked off with REST endpoint

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>io.quarkiverse.temporal</groupId>
         <artifactId>quarkus-temporal-parent</artifactId>
         <version>999-SNAPSHOT</version>
     </parent>
-
     <artifactId>integration-tests</artifactId>
     <name>Temporal - Integration Tests</name>
-
     <properties>
         <skipITs>true</skipITs>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -22,7 +18,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.temporal</groupId>
@@ -62,7 +62,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -96,7 +95,6 @@
             </plugin>
         </plugins>
     </build>
-
     <profiles>
         <profile>
             <id>native-image</id>

--- a/integration-tests/src/main/java/io/quarkiverse/temporal/it/rest/MoneyTransferResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/temporal/it/rest/MoneyTransferResource.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.temporal.it.rest;
+
+import static io.quarkiverse.temporal.Constants.DEFAULT_WORKER_NAME;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkiverse.temporal.it.moneyTransfer.defaultWorker.CoreTransactionDetails;
+import io.quarkiverse.temporal.it.moneyTransfer.shared.MoneyTransferWorkflow;
+import io.quarkiverse.temporal.it.moneyTransfer.shared.TransactionDetails;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+
+@Path("/money-transfer")
+public class MoneyTransferResource {
+
+    @Inject
+    WorkflowClient client;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public TransactionDetails transferMoney(@QueryParam("sourceAccountId") String sourceAccountId,
+            @QueryParam("destinationAccountId") String destinationAccountId,
+            @QueryParam("transactionReferenceId") String transactionReferenceId,
+            @QueryParam("amountToTransfer") int amountToTransfer) {
+        WorkflowOptions options = WorkflowOptions.newBuilder()
+                .setTaskQueue(DEFAULT_WORKER_NAME)
+                .setWorkflowId("money-transfer-workflow")
+                .build();
+
+        MoneyTransferWorkflow workflow = client.newWorkflowStub(MoneyTransferWorkflow.class, options);
+        TransactionDetails transaction = new CoreTransactionDetails(sourceAccountId, destinationAccountId,
+                transactionReferenceId, amountToTransfer);
+        workflow.transfer(transaction);
+        return transaction;
+    }
+}

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 quarkus.http.port=8081
-quarkus.temporal.enable-mock=true
+%test.quarkus.temporal.enable-mock=true


### PR DESCRIPTION
This allows you to run `mvn quarkus:dev` and hit the endpoint to see a real workflow run.

![image](https://github.com/user-attachments/assets/ecdce50b-f12a-4d09-8318-472ef7b9bb6d)
