### PR TITLE
always bind opentracing to otel

### DIFF
--- a/extension/deployment/src/test/java/io/quarkiverse/temporal/deployment/OtelTest.java
+++ b/extension/deployment/src/test/java/io/quarkiverse/temporal/deployment/OtelTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.opentracing.util.GlobalTracer;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
@@ -45,5 +46,10 @@ public class OtelTest {
         WorkerFactoryOptions factoryOptions = (WorkerFactoryOptions) FieldUtils.readField(factory, "factoryOptions", true);
         Assertions.assertEquals(1, factoryOptions.getWorkerInterceptors().length);
         Assertions.assertInstanceOf(OpenTracingWorkerInterceptor.class, factoryOptions.getWorkerInterceptors()[0]);
+    }
+
+    @Test
+    public void testOpenTracingBinding() {
+        Assertions.assertTrue(GlobalTracer.isRegistered());
     }
 }

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/OtelRecorder.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/OtelRecorder.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.temporal;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.opentracingshim.OpenTracingShim;
+import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class OtelRecorder {
+
+    public void bindOpenTracing(ShutdownContext shutdownContext) {
+        // bridge Temporal OpenTracing to OpenTelemetry
+        OpenTelemetry openTelemetry = CDI.current().select(OpenTelemetry.class).get();
+        if (openTelemetry == null) {
+            throw new IllegalStateException("OpenTelemetry not available");
+        }
+
+        io.opentracing.Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
+        io.opentracing.util.GlobalTracer.registerIfAbsent(tracer);
+        shutdownContext.addShutdownTask(tracer::close);
+
+    }
+}


### PR DESCRIPTION
opentracing is only bound to otel when "start-worker" is enabled. This PR fix this issue and add a test to validate it