### PR TITLE
Config to disable OTEL, constant for testing Capability

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-temporal.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-temporal.adoc
@@ -44,6 +44,23 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-telemetry-enabled]]`link:#quarkus-temporal_quarkus-temporal-telemetry-enabled[quarkus.temporal.telemetry.enabled]`
+
+
+[.description]
+--
+Enable OpenTelemetry instrumentation, enabled by default if OpenTelemetry capability is detected.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_TEMPORAL_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_TEMPORAL_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`true`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-start-workers]]`link:#quarkus-temporal_quarkus-temporal-start-workers[quarkus.temporal.start-workers]`
 
 

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/Constants.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/Constants.java
@@ -4,4 +4,6 @@ public interface Constants {
     String DEFAULT_WORKER_NAME = "<default>";
 
     String DEFAULT_WORKFLOW_GROUP_NAME = "<default>";
+
+    String TEMPORAL_TESTING_CAPABILITY = "io.quarkiverse.temporal.test";
 }

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/config/TemporalBuildtimeConfig.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/config/TemporalBuildtimeConfig.java
@@ -29,6 +29,13 @@ public interface TemporalBuildtimeConfig {
     boolean healthEnabled();
 
     /**
+     * Enable OpenTelemetry instrumentation, enabled by default if OpenTelemetry capability is detected.
+     */
+    @WithName("telemetry.enabled")
+    @WithDefault("true")
+    boolean telemetryEnabled();
+
+    /**
      * enable mock for testing
      */
     @WithDefault("true")

--- a/test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
+++ b/test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.temporal.test.deployment;
 
+import static io.quarkiverse.temporal.Constants.TEMPORAL_TESTING_CAPABILITY;
+
 import jakarta.inject.Singleton;
 
 import org.jboss.jandex.ClassType;
@@ -29,7 +31,7 @@ public class TemporalTestProcessor {
 
     @BuildStep
     void capabilities(BuildProducer<CapabilityBuildItem> capabilityProducer) {
-        capabilityProducer.produce(new CapabilityBuildItem("io.quarkiverse.temporal.test", "temporal"));
+        capabilityProducer.produce(new CapabilityBuildItem(TEMPORAL_TESTING_CAPABILITY, "temporal"));
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)


### PR DESCRIPTION
@rmanibus i followed what other plugins do like JDBC etc and they have a telemetry flag to be able to disable it.  Most of theirs are disbaled by default but I like enabled by default with the ability to disable it.

Also made a constant for the CAPABILITY