### PR TITLE
Add options to be able to do gracefull shutdown

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-temporal.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-temporal.adoc
@@ -217,6 +217,27 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`15S`
 
+a| [[quarkus-temporal_quarkus-temporal-termination-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-termination-timeout[`quarkus.temporal.termination-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.temporal.termination-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When set blocks shutdown until all tasks are completed or timeout is reached.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_TEMPORAL_TERMINATION_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_TEMPORAL_TERMINATION_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-build-id]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-build-id[`quarkus.temporal.worker.build-id`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.build-id+++[]
@@ -1241,6 +1262,27 @@ Environment variable: `+++QUARKUS_TEMPORAL_CONNECTION_MTLS_PASSWORD+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
+|
+
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout[`quarkus.temporal.connection.rpc-long-poll-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.temporal.connection.rpc-long-poll-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the rpc timeout value for the following long poll based operations: PollWorkflowTaskQueue, PollActivityTaskQueue, GetWorkflowExecutionHistory. If not set uses Temporal default timeout of 70 seconds.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_TEMPORAL_CONNECTION_RPC_LONG_POLL_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_TEMPORAL_CONNECTION_RPC_LONG_POLL_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-temporal_quarkus.temporal.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-temporal_quarkus.temporal.adoc
@@ -217,6 +217,27 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`15S`
 
+a| [[quarkus-temporal_quarkus-temporal-termination-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-termination-timeout[`quarkus.temporal.termination-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.temporal.termination-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When set blocks shutdown until all tasks are completed or timeout is reached.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_TEMPORAL_TERMINATION_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_TEMPORAL_TERMINATION_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-build-id]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-build-id[`quarkus.temporal.worker.build-id`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.build-id+++[]
@@ -1241,6 +1262,27 @@ Environment variable: `+++QUARKUS_TEMPORAL_CONNECTION_MTLS_PASSWORD+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
+|
+
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout[`quarkus.temporal.connection.rpc-long-poll-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.temporal.connection.rpc-long-poll-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the rpc timeout value for the following long poll based operations: PollWorkflowTaskQueue, PollActivityTaskQueue, GetWorkflowExecutionHistory. If not set uses Temporal default timeout of 70 seconds.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_TEMPORAL_CONNECTION_RPC_LONG_POLL_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_TEMPORAL_CONNECTION_RPC_LONG_POLL_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
 

--- a/extension/deployment/src/test/java/io/quarkiverse/temporal/deployment/ClientConfigTest.java
+++ b/extension/deployment/src/test/java/io/quarkiverse/temporal/deployment/ClientConfigTest.java
@@ -42,9 +42,8 @@ public class ClientConfigTest {
                                     "quarkus.temporal.connection.rpc-retry.maximum-attempts: 19\n" +
                                     "quarkus.temporal.connection.rpc-retry.maximum-interval: 23s\n" +
                                     "quarkus.temporal.connection.rpc-retry.maximum-jitter-coefficient: 0.29\n" +
-                                    "quarkus.temporal.connection.rpc-retry.do-not-retry[0]: NOT_FOUND\n"
-
-                            ),
+                                    "quarkus.temporal.connection.rpc-retry.do-not-retry[0]: NOT_FOUND\n" +
+                                    "quarkus.temporal.connection.rpc-long-poll-timeout: 10s\n"),
                             "application.properties"));
 
     @Inject
@@ -62,6 +61,7 @@ public class ClientConfigTest {
     public void testWorkflowServiceStubsConfiguration() {
         WorkflowServiceStubsOptions options = client.getWorkflowServiceStubs().getOptions();
         Assertions.assertEquals("customTarget:1234", options.getTarget());
+        Assertions.assertEquals(Duration.of(10, ChronoUnit.SECONDS), options.getRpcLongPollTimeout());
         Assertions.assertTrue(options.getEnableHttps());
     }
 

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowServiceStubsRecorder.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowServiceStubsRecorder.java
@@ -69,6 +69,8 @@ public class WorkflowServiceStubsRecorder {
                 .setTarget(connection.target())
                 .setEnableHttps(connection.enableHttps());
 
+        connection.rpcLongPollTimeout().ifPresent(builder::setRpcLongPollTimeout);
+
         // API KEY
         if (connection.apiKey().isPresent()) {
             // Create a Metadata object with the Temporal namespace header key.
@@ -118,6 +120,8 @@ public class WorkflowServiceStubsRecorder {
                                 GrpcClient.Literal.of("temporal-client")))
                 .setMetricsScope(createScope(isMicrometerEnabled))
                 .setRpcRetryOptions(createRpcRetryOptions(connection.rpcRetry()));
+
+        connection.rpcLongPollTimeout().ifPresent(builder::setRpcLongPollTimeout);
 
         MTLSRuntimeConfig mtls = connection.mtls();
 

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/config/ConnectionRuntimeConfig.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/config/ConnectionRuntimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.temporal.config;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import io.grpc.ManagedChannelBuilder;
@@ -39,4 +40,11 @@ public interface ConnectionRuntimeConfig {
      * mTLS Options.
      */
     MTLSRuntimeConfig mtls();
+
+    /**
+     * Sets the rpc timeout value for the following long poll based operations: PollWorkflowTaskQueue, PollActivityTaskQueue,
+     * GetWorkflowExecutionHistory.
+     * If not set uses Temporal default timeout of 70 seconds.
+     */
+    Optional<Duration> rpcLongPollTimeout();
 }

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/config/TemporalRuntimeConfig.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/config/TemporalRuntimeConfig.java
@@ -68,4 +68,9 @@ public interface TemporalRuntimeConfig {
     @WithDefaults
     @WithUnnamedKey(DEFAULT_WORKER_NAME)
     Map<String, WorkflowRuntimeConfig> workflow();
+
+    /**
+     * When set blocks shutdown until all tasks are completed or timeout is reached.
+     */
+    Optional<Duration> terminationTimeout();
 }


### PR DESCRIPTION
In order to do a worker graceful shutdown without having activity timing out we need to be able to set:
- RpcLongPollTimeout
- StickyTaskQueueDrainTimeout
And await termination so we don't shutdown abruptly.

This PR adds `rpcLongPollTimeout` setting so we are able to set that, and also `terminationTimeout` so we are able to decide to await or not during a shutdown.

stickyTaskQueueDrainTimeout is already available, so nothing to do there =)