### PR TITLE
Upgraded Quarkus from 3.27.2 to 3.33.1 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           distribution: 'mandrel'
+          version: '23.1.10.0-Final'
           java-package: 'jdk+fx'
           java-version: '21'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,7 @@ jobs:
       - name: Set up JDK 21
         uses: graalvm/setup-graalvm@v1
         with:
-          distribution: 'mandrel'
-          version: '23.1.10.0-Final'
+          distribution: 'graalvm'
           java-package: 'jdk+fx'
           java-version: '21'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/modules/ROOT/pages/includes/quarkus-temporal.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-temporal.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-netty-allocator-max-order]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-netty-allocator-max-order[`quarkus.temporal.netty.allocator-max-order`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-netty-allocator-max-order]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-netty-allocator-max-order[`+++quarkus.temporal.netty.allocator-max-order+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.netty.allocator-max-order+++[]
 endif::add-copy-button-to-config-props[]
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-enable-mock]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-enable-mock[`quarkus.temporal.enable-mock`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-enable-mock]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-enable-mock[`+++quarkus.temporal.enable-mock+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.enable-mock+++[]
 endif::add-copy-button-to-config-props[]
@@ -49,7 +49,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-channel-type]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-channel-type[`quarkus.temporal.channel-type`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-channel-type]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-channel-type[`+++quarkus.temporal.channel-type+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.channel-type+++[]
 endif::add-copy-button-to-config-props[]
@@ -70,7 +70,7 @@ endif::add-copy-button-to-env-var[]
 a|`quarkus-managed`, `built-in`
 |`+++built-in+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-health-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-health-enabled[`quarkus.temporal.health.enabled`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-health-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-health-enabled[`+++quarkus.temporal.health.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.health.enabled+++[]
 endif::add-copy-button-to-config-props[]
@@ -91,7 +91,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-telemetry-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-telemetry-enabled[`quarkus.temporal.telemetry.enabled`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-telemetry-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-telemetry-enabled[`+++quarkus.temporal.telemetry.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.telemetry.enabled+++[]
 endif::add-copy-button-to-config-props[]
@@ -112,7 +112,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-start-workers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-start-workers[`quarkus.temporal.start-workers`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-start-workers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-start-workers[`+++quarkus.temporal.start-workers+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.start-workers+++[]
 endif::add-copy-button-to-config-props[]
@@ -133,7 +133,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-temporal_quarkus-temporal-namespace]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-namespace[`quarkus.temporal.namespace`]##
+a| [[quarkus-temporal_quarkus-temporal-namespace]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-namespace[`+++quarkus.temporal.namespace+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.namespace+++[]
 endif::add-copy-button-to-config-props[]
@@ -154,7 +154,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++default+++`
 
-a| [[quarkus-temporal_quarkus-temporal-identity]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-identity[`quarkus.temporal.identity`]##
+a| [[quarkus-temporal_quarkus-temporal-identity]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-identity[`+++quarkus.temporal.identity+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.identity+++[]
 endif::add-copy-button-to-config-props[]
@@ -175,7 +175,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-metrics-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-metrics-enabled[`quarkus.temporal.metrics.enabled`]##
+a| [[quarkus-temporal_quarkus-temporal-metrics-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-metrics-enabled[`+++quarkus.temporal.metrics.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.metrics.enabled+++[]
 endif::add-copy-button-to-config-props[]
@@ -196,7 +196,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-temporal_quarkus-temporal-metrics-report-duration]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-metrics-report-duration[`quarkus.temporal.metrics.report.duration`]##
+a| [[quarkus-temporal_quarkus-temporal-metrics-report-duration]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-metrics-report-duration[`+++quarkus.temporal.metrics.report.duration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.metrics.report.duration+++[]
 endif::add-copy-button-to-config-props[]
@@ -217,7 +217,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++15S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-termination-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-termination-timeout[`quarkus.temporal.termination-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-termination-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-termination-timeout[`+++quarkus.temporal.termination-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.termination-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -238,13 +238,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-build-id]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-build-id[`quarkus.temporal.worker.build-id`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-build-id]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-build-id[`+++quarkus.temporal.worker.build-id+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.build-id+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".build-id`
+`+++quarkus.temporal.worker."worker-name".build-id+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".build-id+++[]
 endif::add-copy-button-to-config-props[]
@@ -264,13 +264,13 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-workflow-classes]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-workflow-classes[`quarkus.temporal.worker.workflow-classes`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-workflow-classes]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-workflow-classes[`+++quarkus.temporal.worker.workflow-classes+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.workflow-classes+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".workflow-classes`
+`+++quarkus.temporal.worker."worker-name".workflow-classes+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".workflow-classes+++[]
 endif::add-copy-button-to-config-props[]
@@ -290,13 +290,13 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-activity-classes]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-activity-classes[`quarkus.temporal.worker.activity-classes`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-activity-classes]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-activity-classes[`+++quarkus.temporal.worker.activity-classes+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.activity-classes+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".activity-classes`
+`+++quarkus.temporal.worker."worker-name".activity-classes+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".activity-classes+++[]
 endif::add-copy-button-to-config-props[]
@@ -316,13 +316,13 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-worker-task-queue]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-task-queue[`quarkus.temporal.worker.task-queue`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-task-queue]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-task-queue[`+++quarkus.temporal.worker.task-queue+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.task-queue+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".task-queue`
+`+++quarkus.temporal.worker."worker-name".task-queue+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".task-queue+++[]
 endif::add-copy-button-to-config-props[]
@@ -342,13 +342,13 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-worker-activities-per-second]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-worker-activities-per-second[`quarkus.temporal.worker.max-worker-activities-per-second`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-worker-activities-per-second]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-worker-activities-per-second[`+++quarkus.temporal.worker.max-worker-activities-per-second+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-worker-activities-per-second+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-worker-activities-per-second`
+`+++quarkus.temporal.worker."worker-name".max-worker-activities-per-second+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-worker-activities-per-second+++[]
 endif::add-copy-button-to-config-props[]
@@ -368,13 +368,13 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-execution-size[`quarkus.temporal.worker.max-concurrent-activity-execution-size`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-execution-size[`+++quarkus.temporal.worker.max-concurrent-activity-execution-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-activity-execution-size+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-activity-execution-size`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-activity-execution-size+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-activity-execution-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -394,13 +394,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++200+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-execution-size[`quarkus.temporal.worker.max-concurrent-workflow-task-execution-size`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-execution-size[`+++quarkus.temporal.worker.max-concurrent-workflow-task-execution-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-workflow-task-execution-size+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-execution-size`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-execution-size+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-execution-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -420,13 +420,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++200+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-local-activity-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-local-activity-execution-size[`quarkus.temporal.worker.max-concurrent-local-activity-execution-size`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-local-activity-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-local-activity-execution-size[`+++quarkus.temporal.worker.max-concurrent-local-activity-execution-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-local-activity-execution-size+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-local-activity-execution-size`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-local-activity-execution-size+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-local-activity-execution-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -446,13 +446,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++200+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-task-queue-activities-per-second]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-task-queue-activities-per-second[`quarkus.temporal.worker.max-task-queue-activities-per-second`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-task-queue-activities-per-second]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-task-queue-activities-per-second[`+++quarkus.temporal.worker.max-task-queue-activities-per-second+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-task-queue-activities-per-second+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-task-queue-activities-per-second`
+`+++quarkus.temporal.worker."worker-name".max-task-queue-activities-per-second+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-task-queue-activities-per-second+++[]
 endif::add-copy-button-to-config-props[]
@@ -472,13 +472,13 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-pollers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-pollers[`quarkus.temporal.worker.max-concurrent-workflow-task-pollers`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-pollers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-pollers[`+++quarkus.temporal.worker.max-concurrent-workflow-task-pollers+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-workflow-task-pollers+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-pollers`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-pollers+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-pollers+++[]
 endif::add-copy-button-to-config-props[]
@@ -498,13 +498,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++5+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-task-pollers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-task-pollers[`quarkus.temporal.worker.max-concurrent-activity-task-pollers`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-task-pollers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-task-pollers[`+++quarkus.temporal.worker.max-concurrent-activity-task-pollers+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-activity-task-pollers+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-activity-task-pollers`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-activity-task-pollers+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-activity-task-pollers+++[]
 endif::add-copy-button-to-config-props[]
@@ -524,13 +524,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++5+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-local-activity-worker-only]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-local-activity-worker-only[`quarkus.temporal.worker.local-activity-worker-only`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-local-activity-worker-only]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-local-activity-worker-only[`+++quarkus.temporal.worker.local-activity-worker-only+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.local-activity-worker-only+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".local-activity-worker-only`
+`+++quarkus.temporal.worker."worker-name".local-activity-worker-only+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".local-activity-worker-only+++[]
 endif::add-copy-button-to-config-props[]
@@ -550,13 +550,13 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-default-deadlock-detection-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-default-deadlock-detection-timeout[`quarkus.temporal.worker.default-deadlock-detection-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-default-deadlock-detection-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-default-deadlock-detection-timeout[`+++quarkus.temporal.worker.default-deadlock-detection-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.default-deadlock-detection-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".default-deadlock-detection-timeout`
+`+++quarkus.temporal.worker."worker-name".default-deadlock-detection-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".default-deadlock-detection-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -576,13 +576,13 @@ endif::add-copy-button-to-env-var[]
 |long
 |`+++1000+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-heartbeat-throttle-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-heartbeat-throttle-interval[`quarkus.temporal.worker.max-heartbeat-throttle-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-heartbeat-throttle-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-heartbeat-throttle-interval[`+++quarkus.temporal.worker.max-heartbeat-throttle-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-heartbeat-throttle-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-heartbeat-throttle-interval`
+`+++quarkus.temporal.worker."worker-name".max-heartbeat-throttle-interval+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-heartbeat-throttle-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -602,13 +602,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++60S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-default-heartbeat-throttle-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-default-heartbeat-throttle-interval[`quarkus.temporal.worker.default-heartbeat-throttle-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-default-heartbeat-throttle-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-default-heartbeat-throttle-interval[`+++quarkus.temporal.worker.default-heartbeat-throttle-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.default-heartbeat-throttle-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".default-heartbeat-throttle-interval`
+`+++quarkus.temporal.worker."worker-name".default-heartbeat-throttle-interval+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".default-heartbeat-throttle-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -628,13 +628,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++30S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-sticky-queue-schedule-to-start-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-sticky-queue-schedule-to-start-timeout[`quarkus.temporal.worker.sticky-queue-schedule-to-start-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-sticky-queue-schedule-to-start-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-sticky-queue-schedule-to-start-timeout[`+++quarkus.temporal.worker.sticky-queue-schedule-to-start-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.sticky-queue-schedule-to-start-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".sticky-queue-schedule-to-start-timeout`
+`+++quarkus.temporal.worker."worker-name".sticky-queue-schedule-to-start-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".sticky-queue-schedule-to-start-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -654,13 +654,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++5S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-disable-eager-execution]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-disable-eager-execution[`quarkus.temporal.worker.disable-eager-execution`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-disable-eager-execution]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-disable-eager-execution[`+++quarkus.temporal.worker.disable-eager-execution+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.disable-eager-execution+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".disable-eager-execution`
+`+++quarkus.temporal.worker."worker-name".disable-eager-execution+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".disable-eager-execution+++[]
 endif::add-copy-button-to-config-props[]
@@ -680,13 +680,13 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-use-build-id-for-versioning]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-use-build-id-for-versioning[`quarkus.temporal.worker.use-build-id-for-versioning`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-use-build-id-for-versioning]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-use-build-id-for-versioning[`+++quarkus.temporal.worker.use-build-id-for-versioning+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.use-build-id-for-versioning+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".use-build-id-for-versioning`
+`+++quarkus.temporal.worker."worker-name".use-build-id-for-versioning+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".use-build-id-for-versioning+++[]
 endif::add-copy-button-to-config-props[]
@@ -706,13 +706,13 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-sticky-task-queue-drain-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-sticky-task-queue-drain-timeout[`quarkus.temporal.worker.sticky-task-queue-drain-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-sticky-task-queue-drain-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-sticky-task-queue-drain-timeout[`+++quarkus.temporal.worker.sticky-task-queue-drain-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.sticky-task-queue-drain-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".sticky-task-queue-drain-timeout`
+`+++quarkus.temporal.worker."worker-name".sticky-task-queue-drain-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".sticky-task-queue-drain-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -732,13 +732,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++0S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-identity]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-identity[`quarkus.temporal.worker.identity`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-identity]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-identity[`+++quarkus.temporal.worker.identity+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.identity+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".identity`
+`+++quarkus.temporal.worker."worker-name".identity+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".identity+++[]
 endif::add-copy-button-to-config-props[]
@@ -758,13 +758,13 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-id-reuse-policy]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-id-reuse-policy[`quarkus.temporal.workflow.workflow-id-reuse-policy`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-id-reuse-policy]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-id-reuse-policy[`+++quarkus.temporal.workflow.workflow-id-reuse-policy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-id-reuse-policy+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-id-reuse-policy`
+`+++quarkus.temporal.workflow."group-name".workflow-id-reuse-policy+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-id-reuse-policy+++[]
 endif::add-copy-button-to-config-props[]
@@ -784,13 +784,13 @@ endif::add-copy-button-to-env-var[]
 a|`unspecified`, `allow-duplicate`, `allow-duplicate-failed-only`, `reject-duplicate`, `terminate-if-running`
 |`+++allow-duplicate+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-id-conflict-policy]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-id-conflict-policy[`quarkus.temporal.workflow.workflow-id-conflict-policy`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-id-conflict-policy]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-id-conflict-policy[`+++quarkus.temporal.workflow.workflow-id-conflict-policy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-id-conflict-policy+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-id-conflict-policy`
+`+++quarkus.temporal.workflow."group-name".workflow-id-conflict-policy+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-id-conflict-policy+++[]
 endif::add-copy-button-to-config-props[]
@@ -810,13 +810,13 @@ endif::add-copy-button-to-env-var[]
 a|`unspecified`, `fail`, `use-existing`, `terminate-existing`
 |`+++fail+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-run-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-run-timeout[`quarkus.temporal.workflow.workflow-run-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-run-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-run-timeout[`+++quarkus.temporal.workflow.workflow-run-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-run-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-run-timeout`
+`+++quarkus.temporal.workflow."group-name".workflow-run-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-run-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -836,13 +836,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-execution-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-execution-timeout[`quarkus.temporal.workflow.workflow-execution-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-execution-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-execution-timeout[`+++quarkus.temporal.workflow.workflow-execution-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-execution-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-execution-timeout`
+`+++quarkus.temporal.workflow."group-name".workflow-execution-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-execution-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -862,13 +862,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-task-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-task-timeout[`quarkus.temporal.workflow.workflow-task-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-task-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-task-timeout[`+++quarkus.temporal.workflow.workflow-task-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-task-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-task-timeout`
+`+++quarkus.temporal.workflow."group-name".workflow-task-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-task-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -888,13 +888,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++10S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-cron-schedule]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-cron-schedule[`quarkus.temporal.workflow.cron-schedule`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-cron-schedule]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-cron-schedule[`+++quarkus.temporal.workflow.cron-schedule+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.cron-schedule+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".cron-schedule`
+`+++quarkus.temporal.workflow."group-name".cron-schedule+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".cron-schedule+++[]
 endif::add-copy-button-to-config-props[]
@@ -914,13 +914,13 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-disable-eager-execution]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-disable-eager-execution[`quarkus.temporal.workflow.disable-eager-execution`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-disable-eager-execution]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-disable-eager-execution[`+++quarkus.temporal.workflow.disable-eager-execution+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.disable-eager-execution+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".disable-eager-execution`
+`+++quarkus.temporal.workflow."group-name".disable-eager-execution+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".disable-eager-execution+++[]
 endif::add-copy-button-to-config-props[]
@@ -940,13 +940,13 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-start-delay]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-start-delay[`quarkus.temporal.workflow.start-delay`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-start-delay]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-start-delay[`+++quarkus.temporal.workflow.start-delay+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.start-delay+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".start-delay`
+`+++quarkus.temporal.workflow."group-name".start-delay+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".start-delay+++[]
 endif::add-copy-button-to-config-props[]
@@ -970,7 +970,7 @@ h|[[quarkus-temporal_section_quarkus-temporal-connection]] [.section-name.sectio
 h|Type
 h|Default
 
-a| [[quarkus-temporal_quarkus-temporal-connection-target]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-target[`quarkus.temporal.connection.target`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-target]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-target[`+++quarkus.temporal.connection.target+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.target+++[]
 endif::add-copy-button-to-config-props[]
@@ -991,7 +991,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++127.0.0.1:7233+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-enable-https]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-enable-https[`quarkus.temporal.connection.enable-https`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-enable-https]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-enable-https[`+++quarkus.temporal.connection.enable-https+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.enable-https+++[]
 endif::add-copy-button-to-config-props[]
@@ -1012,7 +1012,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-api-key]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-api-key[`quarkus.temporal.connection.api-key`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-api-key]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-api-key[`+++quarkus.temporal.connection.api-key+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.api-key+++[]
 endif::add-copy-button-to-config-props[]
@@ -1033,7 +1033,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-initial-interval[`quarkus.temporal.connection.rpc-retry.initial-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-initial-interval[`+++quarkus.temporal.connection.rpc-retry.initial-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.initial-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1054,7 +1054,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++100MS+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-congestion-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-congestion-initial-interval[`quarkus.temporal.connection.rpc-retry.congestion-initial-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-congestion-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-congestion-initial-interval[`+++quarkus.temporal.connection.rpc-retry.congestion-initial-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.congestion-initial-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1075,7 +1075,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++1000MS+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-expiration]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-expiration[`quarkus.temporal.connection.rpc-retry.expiration`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-expiration]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-expiration[`+++quarkus.temporal.connection.rpc-retry.expiration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.expiration+++[]
 endif::add-copy-button-to-config-props[]
@@ -1096,7 +1096,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++1M+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-backoff-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-backoff-coefficient[`quarkus.temporal.connection.rpc-retry.backoff-coefficient`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-backoff-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-backoff-coefficient[`+++quarkus.temporal.connection.rpc-retry.backoff-coefficient+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.backoff-coefficient+++[]
 endif::add-copy-button-to-config-props[]
@@ -1117,7 +1117,7 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++1.5+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-attempts[`quarkus.temporal.connection.rpc-retry.maximum-attempts`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-attempts[`+++quarkus.temporal.connection.rpc-retry.maximum-attempts+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.maximum-attempts+++[]
 endif::add-copy-button-to-config-props[]
@@ -1138,7 +1138,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-interval[`quarkus.temporal.connection.rpc-retry.maximum-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-interval[`+++quarkus.temporal.connection.rpc-retry.maximum-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.maximum-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1159,7 +1159,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-jitter-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-jitter-coefficient[`quarkus.temporal.connection.rpc-retry.maximum-jitter-coefficient`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-jitter-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-jitter-coefficient[`+++quarkus.temporal.connection.rpc-retry.maximum-jitter-coefficient+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.maximum-jitter-coefficient+++[]
 endif::add-copy-button-to-config-props[]
@@ -1180,7 +1180,7 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++0.2+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-do-not-retry]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-do-not-retry[`quarkus.temporal.connection.rpc-retry.do-not-retry`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-do-not-retry]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-do-not-retry[`+++quarkus.temporal.connection.rpc-retry.do-not-retry+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.do-not-retry+++[]
 endif::add-copy-button-to-config-props[]
@@ -1201,7 +1201,7 @@ endif::add-copy-button-to-env-var[]
 a|list of `ok`, `cancelled`, `unknown`, `invalid-argument`, `deadline-exceeded`, `not-found`, `already-exists`, `permission-denied`, `resource-exhausted`, `failed-precondition`, `aborted`, `out-of-range`, `unimplemented`, `internal`, `unavailable`, `data-loss`, `unauthenticated`
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-mtls-client-cert-path]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-client-cert-path[`quarkus.temporal.connection.mtls.client-cert-path`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-mtls-client-cert-path]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-client-cert-path[`+++quarkus.temporal.connection.mtls.client-cert-path+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.mtls.client-cert-path+++[]
 endif::add-copy-button-to-config-props[]
@@ -1222,7 +1222,7 @@ endif::add-copy-button-to-env-var[]
 |path
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-mtls-client-key-path]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-client-key-path[`quarkus.temporal.connection.mtls.client-key-path`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-mtls-client-key-path]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-client-key-path[`+++quarkus.temporal.connection.mtls.client-key-path+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.mtls.client-key-path+++[]
 endif::add-copy-button-to-config-props[]
@@ -1243,7 +1243,7 @@ endif::add-copy-button-to-env-var[]
 |path
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-mtls-password]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-password[`quarkus.temporal.connection.mtls.password`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-mtls-password]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-password[`+++quarkus.temporal.connection.mtls.password+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.mtls.password+++[]
 endif::add-copy-button-to-config-props[]
@@ -1264,7 +1264,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout[`quarkus.temporal.connection.rpc-long-poll-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout[`+++quarkus.temporal.connection.rpc-long-poll-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-long-poll-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -1290,13 +1290,13 @@ h|[[quarkus-temporal_section_quarkus-temporal-workflow-retries]] [.section-name.
 h|Type
 h|Default
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-do-not-retry]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-do-not-retry[`quarkus.temporal.workflow.retries.do-not-retry`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-do-not-retry]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-do-not-retry[`+++quarkus.temporal.workflow.retries.do-not-retry+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.do-not-retry+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.do-not-retry`
+`+++quarkus.temporal.workflow."group-name".retries.do-not-retry+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.do-not-retry+++[]
 endif::add-copy-button-to-config-props[]
@@ -1316,13 +1316,13 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++[]+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-initial-interval[`quarkus.temporal.workflow.retries.initial-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-initial-interval[`+++quarkus.temporal.workflow.retries.initial-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.initial-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.initial-interval`
+`+++quarkus.temporal.workflow."group-name".retries.initial-interval+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.initial-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1342,13 +1342,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++1S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-backoff-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-backoff-coefficient[`quarkus.temporal.workflow.retries.backoff-coefficient`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-backoff-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-backoff-coefficient[`+++quarkus.temporal.workflow.retries.backoff-coefficient+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.backoff-coefficient+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.backoff-coefficient`
+`+++quarkus.temporal.workflow."group-name".retries.backoff-coefficient+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.backoff-coefficient+++[]
 endif::add-copy-button-to-config-props[]
@@ -1368,13 +1368,13 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++2.0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-set-maximum-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-set-maximum-attempts[`quarkus.temporal.workflow.retries.set-maximum-attempts`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-set-maximum-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-set-maximum-attempts[`+++quarkus.temporal.workflow.retries.set-maximum-attempts+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.set-maximum-attempts+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.set-maximum-attempts`
+`+++quarkus.temporal.workflow."group-name".retries.set-maximum-attempts+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.set-maximum-attempts+++[]
 endif::add-copy-button-to-config-props[]
@@ -1394,13 +1394,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-maximum-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-maximum-interval[`quarkus.temporal.workflow.retries.maximum-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-maximum-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-maximum-interval[`+++quarkus.temporal.workflow.retries.maximum-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.maximum-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.maximum-interval`
+`+++quarkus.temporal.workflow."group-name".retries.maximum-interval+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.maximum-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1425,7 +1425,7 @@ h|[[quarkus-temporal_section_quarkus-temporal-worker-factory]] [.section-name.se
 h|Type
 h|Default
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-using-virtual-workflow-threads]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-using-virtual-workflow-threads[`quarkus.temporal.worker-factory.using-virtual-workflow-threads`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-using-virtual-workflow-threads]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-using-virtual-workflow-threads[`+++quarkus.temporal.worker-factory.using-virtual-workflow-threads+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.using-virtual-workflow-threads+++[]
 endif::add-copy-button-to-config-props[]
@@ -1446,7 +1446,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-max-workflow-thread-count]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-max-workflow-thread-count[`quarkus.temporal.worker-factory.max-workflow-thread-count`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-max-workflow-thread-count]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-max-workflow-thread-count[`+++quarkus.temporal.worker-factory.max-workflow-thread-count+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.max-workflow-thread-count+++[]
 endif::add-copy-button-to-config-props[]
@@ -1467,7 +1467,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++600+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-workflow-cache-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-workflow-cache-size[`quarkus.temporal.worker-factory.workflow-cache-size`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-workflow-cache-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-workflow-cache-size[`+++quarkus.temporal.worker-factory.workflow-cache-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.workflow-cache-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -1488,7 +1488,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++600+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-fail-on-startup-error]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-fail-on-startup-error[`quarkus.temporal.worker-factory.fail-on-startup-error`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-fail-on-startup-error]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-fail-on-startup-error[`+++quarkus.temporal.worker-factory.fail-on-startup-error+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.fail-on-startup-error+++[]
 endif::add-copy-button-to-config-props[]
@@ -1509,7 +1509,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-max-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-max-attempts[`quarkus.temporal.worker-factory.startup-max-attempts`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-max-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-max-attempts[`+++quarkus.temporal.worker-factory.startup-max-attempts+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.startup-max-attempts+++[]
 endif::add-copy-button-to-config-props[]
@@ -1530,7 +1530,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++1+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-retry-delay]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-retry-delay[`quarkus.temporal.worker-factory.startup-retry-delay`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-retry-delay]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-retry-delay[`+++quarkus.temporal.worker-factory.startup-retry-delay+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.startup-retry-delay+++[]
 endif::add-copy-button-to-config-props[]
@@ -1551,7 +1551,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++2S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-background-retry-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-background-retry-enabled[`quarkus.temporal.worker-factory.startup-background-retry-enabled`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-background-retry-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-background-retry-enabled[`+++quarkus.temporal.worker-factory.startup-background-retry-enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.startup-background-retry-enabled+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-temporal_quarkus.temporal.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-temporal_quarkus.temporal.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-netty-allocator-max-order]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-netty-allocator-max-order[`quarkus.temporal.netty.allocator-max-order`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-netty-allocator-max-order]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-netty-allocator-max-order[`+++quarkus.temporal.netty.allocator-max-order+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.netty.allocator-max-order+++[]
 endif::add-copy-button-to-config-props[]
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-enable-mock]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-enable-mock[`quarkus.temporal.enable-mock`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-enable-mock]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-enable-mock[`+++quarkus.temporal.enable-mock+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.enable-mock+++[]
 endif::add-copy-button-to-config-props[]
@@ -49,7 +49,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-channel-type]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-channel-type[`quarkus.temporal.channel-type`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-channel-type]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-channel-type[`+++quarkus.temporal.channel-type+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.channel-type+++[]
 endif::add-copy-button-to-config-props[]
@@ -70,7 +70,7 @@ endif::add-copy-button-to-env-var[]
 a|`quarkus-managed`, `built-in`
 |`+++built-in+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-health-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-health-enabled[`quarkus.temporal.health.enabled`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-health-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-health-enabled[`+++quarkus.temporal.health.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.health.enabled+++[]
 endif::add-copy-button-to-config-props[]
@@ -91,7 +91,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-telemetry-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-telemetry-enabled[`quarkus.temporal.telemetry.enabled`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-telemetry-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-telemetry-enabled[`+++quarkus.temporal.telemetry.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.telemetry.enabled+++[]
 endif::add-copy-button-to-config-props[]
@@ -112,7 +112,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-start-workers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-start-workers[`quarkus.temporal.start-workers`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-start-workers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-start-workers[`+++quarkus.temporal.start-workers+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.start-workers+++[]
 endif::add-copy-button-to-config-props[]
@@ -133,7 +133,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-temporal_quarkus-temporal-namespace]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-namespace[`quarkus.temporal.namespace`]##
+a| [[quarkus-temporal_quarkus-temporal-namespace]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-namespace[`+++quarkus.temporal.namespace+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.namespace+++[]
 endif::add-copy-button-to-config-props[]
@@ -154,7 +154,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++default+++`
 
-a| [[quarkus-temporal_quarkus-temporal-identity]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-identity[`quarkus.temporal.identity`]##
+a| [[quarkus-temporal_quarkus-temporal-identity]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-identity[`+++quarkus.temporal.identity+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.identity+++[]
 endif::add-copy-button-to-config-props[]
@@ -175,7 +175,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-metrics-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-metrics-enabled[`quarkus.temporal.metrics.enabled`]##
+a| [[quarkus-temporal_quarkus-temporal-metrics-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-metrics-enabled[`+++quarkus.temporal.metrics.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.metrics.enabled+++[]
 endif::add-copy-button-to-config-props[]
@@ -196,7 +196,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-temporal_quarkus-temporal-metrics-report-duration]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-metrics-report-duration[`quarkus.temporal.metrics.report.duration`]##
+a| [[quarkus-temporal_quarkus-temporal-metrics-report-duration]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-metrics-report-duration[`+++quarkus.temporal.metrics.report.duration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.metrics.report.duration+++[]
 endif::add-copy-button-to-config-props[]
@@ -217,7 +217,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++15S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-termination-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-termination-timeout[`quarkus.temporal.termination-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-termination-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-termination-timeout[`+++quarkus.temporal.termination-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.termination-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -238,13 +238,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-build-id]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-build-id[`quarkus.temporal.worker.build-id`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-build-id]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-build-id[`+++quarkus.temporal.worker.build-id+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.build-id+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".build-id`
+`+++quarkus.temporal.worker."worker-name".build-id+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".build-id+++[]
 endif::add-copy-button-to-config-props[]
@@ -264,13 +264,13 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-workflow-classes]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-workflow-classes[`quarkus.temporal.worker.workflow-classes`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-workflow-classes]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-workflow-classes[`+++quarkus.temporal.worker.workflow-classes+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.workflow-classes+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".workflow-classes`
+`+++quarkus.temporal.worker."worker-name".workflow-classes+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".workflow-classes+++[]
 endif::add-copy-button-to-config-props[]
@@ -290,13 +290,13 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-activity-classes]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-activity-classes[`quarkus.temporal.worker.activity-classes`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-temporal_quarkus-temporal-worker-activity-classes]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-activity-classes[`+++quarkus.temporal.worker.activity-classes+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.activity-classes+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".activity-classes`
+`+++quarkus.temporal.worker."worker-name".activity-classes+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".activity-classes+++[]
 endif::add-copy-button-to-config-props[]
@@ -316,13 +316,13 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-worker-task-queue]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-task-queue[`quarkus.temporal.worker.task-queue`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-task-queue]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-task-queue[`+++quarkus.temporal.worker.task-queue+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.task-queue+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".task-queue`
+`+++quarkus.temporal.worker."worker-name".task-queue+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".task-queue+++[]
 endif::add-copy-button-to-config-props[]
@@ -342,13 +342,13 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-worker-activities-per-second]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-worker-activities-per-second[`quarkus.temporal.worker.max-worker-activities-per-second`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-worker-activities-per-second]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-worker-activities-per-second[`+++quarkus.temporal.worker.max-worker-activities-per-second+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-worker-activities-per-second+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-worker-activities-per-second`
+`+++quarkus.temporal.worker."worker-name".max-worker-activities-per-second+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-worker-activities-per-second+++[]
 endif::add-copy-button-to-config-props[]
@@ -368,13 +368,13 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-execution-size[`quarkus.temporal.worker.max-concurrent-activity-execution-size`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-execution-size[`+++quarkus.temporal.worker.max-concurrent-activity-execution-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-activity-execution-size+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-activity-execution-size`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-activity-execution-size+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-activity-execution-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -394,13 +394,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++200+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-execution-size[`quarkus.temporal.worker.max-concurrent-workflow-task-execution-size`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-execution-size[`+++quarkus.temporal.worker.max-concurrent-workflow-task-execution-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-workflow-task-execution-size+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-execution-size`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-execution-size+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-execution-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -420,13 +420,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++200+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-local-activity-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-local-activity-execution-size[`quarkus.temporal.worker.max-concurrent-local-activity-execution-size`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-local-activity-execution-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-local-activity-execution-size[`+++quarkus.temporal.worker.max-concurrent-local-activity-execution-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-local-activity-execution-size+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-local-activity-execution-size`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-local-activity-execution-size+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-local-activity-execution-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -446,13 +446,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++200+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-task-queue-activities-per-second]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-task-queue-activities-per-second[`quarkus.temporal.worker.max-task-queue-activities-per-second`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-task-queue-activities-per-second]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-task-queue-activities-per-second[`+++quarkus.temporal.worker.max-task-queue-activities-per-second+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-task-queue-activities-per-second+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-task-queue-activities-per-second`
+`+++quarkus.temporal.worker."worker-name".max-task-queue-activities-per-second+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-task-queue-activities-per-second+++[]
 endif::add-copy-button-to-config-props[]
@@ -472,13 +472,13 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-pollers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-pollers[`quarkus.temporal.worker.max-concurrent-workflow-task-pollers`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-pollers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-workflow-task-pollers[`+++quarkus.temporal.worker.max-concurrent-workflow-task-pollers+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-workflow-task-pollers+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-pollers`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-pollers+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-workflow-task-pollers+++[]
 endif::add-copy-button-to-config-props[]
@@ -498,13 +498,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++5+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-task-pollers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-task-pollers[`quarkus.temporal.worker.max-concurrent-activity-task-pollers`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-task-pollers]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-concurrent-activity-task-pollers[`+++quarkus.temporal.worker.max-concurrent-activity-task-pollers+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-concurrent-activity-task-pollers+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-concurrent-activity-task-pollers`
+`+++quarkus.temporal.worker."worker-name".max-concurrent-activity-task-pollers+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-concurrent-activity-task-pollers+++[]
 endif::add-copy-button-to-config-props[]
@@ -524,13 +524,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++5+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-local-activity-worker-only]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-local-activity-worker-only[`quarkus.temporal.worker.local-activity-worker-only`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-local-activity-worker-only]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-local-activity-worker-only[`+++quarkus.temporal.worker.local-activity-worker-only+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.local-activity-worker-only+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".local-activity-worker-only`
+`+++quarkus.temporal.worker."worker-name".local-activity-worker-only+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".local-activity-worker-only+++[]
 endif::add-copy-button-to-config-props[]
@@ -550,13 +550,13 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-default-deadlock-detection-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-default-deadlock-detection-timeout[`quarkus.temporal.worker.default-deadlock-detection-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-default-deadlock-detection-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-default-deadlock-detection-timeout[`+++quarkus.temporal.worker.default-deadlock-detection-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.default-deadlock-detection-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".default-deadlock-detection-timeout`
+`+++quarkus.temporal.worker."worker-name".default-deadlock-detection-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".default-deadlock-detection-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -576,13 +576,13 @@ endif::add-copy-button-to-env-var[]
 |long
 |`+++1000+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-max-heartbeat-throttle-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-heartbeat-throttle-interval[`quarkus.temporal.worker.max-heartbeat-throttle-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-max-heartbeat-throttle-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-max-heartbeat-throttle-interval[`+++quarkus.temporal.worker.max-heartbeat-throttle-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.max-heartbeat-throttle-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".max-heartbeat-throttle-interval`
+`+++quarkus.temporal.worker."worker-name".max-heartbeat-throttle-interval+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".max-heartbeat-throttle-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -602,13 +602,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++60S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-default-heartbeat-throttle-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-default-heartbeat-throttle-interval[`quarkus.temporal.worker.default-heartbeat-throttle-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-default-heartbeat-throttle-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-default-heartbeat-throttle-interval[`+++quarkus.temporal.worker.default-heartbeat-throttle-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.default-heartbeat-throttle-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".default-heartbeat-throttle-interval`
+`+++quarkus.temporal.worker."worker-name".default-heartbeat-throttle-interval+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".default-heartbeat-throttle-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -628,13 +628,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++30S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-sticky-queue-schedule-to-start-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-sticky-queue-schedule-to-start-timeout[`quarkus.temporal.worker.sticky-queue-schedule-to-start-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-sticky-queue-schedule-to-start-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-sticky-queue-schedule-to-start-timeout[`+++quarkus.temporal.worker.sticky-queue-schedule-to-start-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.sticky-queue-schedule-to-start-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".sticky-queue-schedule-to-start-timeout`
+`+++quarkus.temporal.worker."worker-name".sticky-queue-schedule-to-start-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".sticky-queue-schedule-to-start-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -654,13 +654,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++5S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-disable-eager-execution]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-disable-eager-execution[`quarkus.temporal.worker.disable-eager-execution`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-disable-eager-execution]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-disable-eager-execution[`+++quarkus.temporal.worker.disable-eager-execution+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.disable-eager-execution+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".disable-eager-execution`
+`+++quarkus.temporal.worker."worker-name".disable-eager-execution+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".disable-eager-execution+++[]
 endif::add-copy-button-to-config-props[]
@@ -680,13 +680,13 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-use-build-id-for-versioning]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-use-build-id-for-versioning[`quarkus.temporal.worker.use-build-id-for-versioning`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-use-build-id-for-versioning]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-use-build-id-for-versioning[`+++quarkus.temporal.worker.use-build-id-for-versioning+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.use-build-id-for-versioning+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".use-build-id-for-versioning`
+`+++quarkus.temporal.worker."worker-name".use-build-id-for-versioning+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".use-build-id-for-versioning+++[]
 endif::add-copy-button-to-config-props[]
@@ -706,13 +706,13 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-sticky-task-queue-drain-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-sticky-task-queue-drain-timeout[`quarkus.temporal.worker.sticky-task-queue-drain-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-sticky-task-queue-drain-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-sticky-task-queue-drain-timeout[`+++quarkus.temporal.worker.sticky-task-queue-drain-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.sticky-task-queue-drain-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".sticky-task-queue-drain-timeout`
+`+++quarkus.temporal.worker."worker-name".sticky-task-queue-drain-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".sticky-task-queue-drain-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -732,13 +732,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++0S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-identity]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-identity[`quarkus.temporal.worker.identity`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-identity]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-identity[`+++quarkus.temporal.worker.identity+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker.identity+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.worker."worker-name".identity`
+`+++quarkus.temporal.worker."worker-name".identity+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker."worker-name".identity+++[]
 endif::add-copy-button-to-config-props[]
@@ -758,13 +758,13 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-id-reuse-policy]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-id-reuse-policy[`quarkus.temporal.workflow.workflow-id-reuse-policy`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-id-reuse-policy]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-id-reuse-policy[`+++quarkus.temporal.workflow.workflow-id-reuse-policy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-id-reuse-policy+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-id-reuse-policy`
+`+++quarkus.temporal.workflow."group-name".workflow-id-reuse-policy+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-id-reuse-policy+++[]
 endif::add-copy-button-to-config-props[]
@@ -784,13 +784,13 @@ endif::add-copy-button-to-env-var[]
 a|`unspecified`, `allow-duplicate`, `allow-duplicate-failed-only`, `reject-duplicate`, `terminate-if-running`
 |`+++allow-duplicate+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-id-conflict-policy]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-id-conflict-policy[`quarkus.temporal.workflow.workflow-id-conflict-policy`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-id-conflict-policy]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-id-conflict-policy[`+++quarkus.temporal.workflow.workflow-id-conflict-policy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-id-conflict-policy+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-id-conflict-policy`
+`+++quarkus.temporal.workflow."group-name".workflow-id-conflict-policy+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-id-conflict-policy+++[]
 endif::add-copy-button-to-config-props[]
@@ -810,13 +810,13 @@ endif::add-copy-button-to-env-var[]
 a|`unspecified`, `fail`, `use-existing`, `terminate-existing`
 |`+++fail+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-run-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-run-timeout[`quarkus.temporal.workflow.workflow-run-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-run-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-run-timeout[`+++quarkus.temporal.workflow.workflow-run-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-run-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-run-timeout`
+`+++quarkus.temporal.workflow."group-name".workflow-run-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-run-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -836,13 +836,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-execution-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-execution-timeout[`quarkus.temporal.workflow.workflow-execution-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-execution-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-execution-timeout[`+++quarkus.temporal.workflow.workflow-execution-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-execution-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-execution-timeout`
+`+++quarkus.temporal.workflow."group-name".workflow-execution-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-execution-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -862,13 +862,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-task-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-task-timeout[`quarkus.temporal.workflow.workflow-task-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-workflow-task-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-workflow-task-timeout[`+++quarkus.temporal.workflow.workflow-task-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.workflow-task-timeout+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".workflow-task-timeout`
+`+++quarkus.temporal.workflow."group-name".workflow-task-timeout+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".workflow-task-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -888,13 +888,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++10S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-cron-schedule]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-cron-schedule[`quarkus.temporal.workflow.cron-schedule`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-cron-schedule]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-cron-schedule[`+++quarkus.temporal.workflow.cron-schedule+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.cron-schedule+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".cron-schedule`
+`+++quarkus.temporal.workflow."group-name".cron-schedule+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".cron-schedule+++[]
 endif::add-copy-button-to-config-props[]
@@ -914,13 +914,13 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-disable-eager-execution]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-disable-eager-execution[`quarkus.temporal.workflow.disable-eager-execution`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-disable-eager-execution]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-disable-eager-execution[`+++quarkus.temporal.workflow.disable-eager-execution+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.disable-eager-execution+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".disable-eager-execution`
+`+++quarkus.temporal.workflow."group-name".disable-eager-execution+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".disable-eager-execution+++[]
 endif::add-copy-button-to-config-props[]
@@ -940,13 +940,13 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-start-delay]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-start-delay[`quarkus.temporal.workflow.start-delay`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-start-delay]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-start-delay[`+++quarkus.temporal.workflow.start-delay+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.start-delay+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".start-delay`
+`+++quarkus.temporal.workflow."group-name".start-delay+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".start-delay+++[]
 endif::add-copy-button-to-config-props[]
@@ -970,7 +970,7 @@ h|[[quarkus-temporal_section_quarkus-temporal-connection]] [.section-name.sectio
 h|Type
 h|Default
 
-a| [[quarkus-temporal_quarkus-temporal-connection-target]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-target[`quarkus.temporal.connection.target`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-target]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-target[`+++quarkus.temporal.connection.target+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.target+++[]
 endif::add-copy-button-to-config-props[]
@@ -991,7 +991,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++127.0.0.1:7233+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-enable-https]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-enable-https[`quarkus.temporal.connection.enable-https`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-enable-https]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-enable-https[`+++quarkus.temporal.connection.enable-https+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.enable-https+++[]
 endif::add-copy-button-to-config-props[]
@@ -1012,7 +1012,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-api-key]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-api-key[`quarkus.temporal.connection.api-key`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-api-key]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-api-key[`+++quarkus.temporal.connection.api-key+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.api-key+++[]
 endif::add-copy-button-to-config-props[]
@@ -1033,7 +1033,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-initial-interval[`quarkus.temporal.connection.rpc-retry.initial-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-initial-interval[`+++quarkus.temporal.connection.rpc-retry.initial-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.initial-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1054,7 +1054,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++100MS+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-congestion-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-congestion-initial-interval[`quarkus.temporal.connection.rpc-retry.congestion-initial-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-congestion-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-congestion-initial-interval[`+++quarkus.temporal.connection.rpc-retry.congestion-initial-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.congestion-initial-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1075,7 +1075,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++1000MS+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-expiration]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-expiration[`quarkus.temporal.connection.rpc-retry.expiration`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-expiration]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-expiration[`+++quarkus.temporal.connection.rpc-retry.expiration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.expiration+++[]
 endif::add-copy-button-to-config-props[]
@@ -1096,7 +1096,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++1M+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-backoff-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-backoff-coefficient[`quarkus.temporal.connection.rpc-retry.backoff-coefficient`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-backoff-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-backoff-coefficient[`+++quarkus.temporal.connection.rpc-retry.backoff-coefficient+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.backoff-coefficient+++[]
 endif::add-copy-button-to-config-props[]
@@ -1117,7 +1117,7 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++1.5+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-attempts[`quarkus.temporal.connection.rpc-retry.maximum-attempts`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-attempts[`+++quarkus.temporal.connection.rpc-retry.maximum-attempts+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.maximum-attempts+++[]
 endif::add-copy-button-to-config-props[]
@@ -1138,7 +1138,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-interval[`quarkus.temporal.connection.rpc-retry.maximum-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-interval[`+++quarkus.temporal.connection.rpc-retry.maximum-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.maximum-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1159,7 +1159,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-jitter-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-jitter-coefficient[`quarkus.temporal.connection.rpc-retry.maximum-jitter-coefficient`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-jitter-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-maximum-jitter-coefficient[`+++quarkus.temporal.connection.rpc-retry.maximum-jitter-coefficient+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.maximum-jitter-coefficient+++[]
 endif::add-copy-button-to-config-props[]
@@ -1180,7 +1180,7 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++0.2+++`
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-do-not-retry]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-do-not-retry[`quarkus.temporal.connection.rpc-retry.do-not-retry`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-retry-do-not-retry]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-retry-do-not-retry[`+++quarkus.temporal.connection.rpc-retry.do-not-retry+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-retry.do-not-retry+++[]
 endif::add-copy-button-to-config-props[]
@@ -1201,7 +1201,7 @@ endif::add-copy-button-to-env-var[]
 a|list of `ok`, `cancelled`, `unknown`, `invalid-argument`, `deadline-exceeded`, `not-found`, `already-exists`, `permission-denied`, `resource-exhausted`, `failed-precondition`, `aborted`, `out-of-range`, `unimplemented`, `internal`, `unavailable`, `data-loss`, `unauthenticated`
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-mtls-client-cert-path]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-client-cert-path[`quarkus.temporal.connection.mtls.client-cert-path`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-mtls-client-cert-path]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-client-cert-path[`+++quarkus.temporal.connection.mtls.client-cert-path+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.mtls.client-cert-path+++[]
 endif::add-copy-button-to-config-props[]
@@ -1222,7 +1222,7 @@ endif::add-copy-button-to-env-var[]
 |path
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-mtls-client-key-path]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-client-key-path[`quarkus.temporal.connection.mtls.client-key-path`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-mtls-client-key-path]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-client-key-path[`+++quarkus.temporal.connection.mtls.client-key-path+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.mtls.client-key-path+++[]
 endif::add-copy-button-to-config-props[]
@@ -1243,7 +1243,7 @@ endif::add-copy-button-to-env-var[]
 |path
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-mtls-password]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-password[`quarkus.temporal.connection.mtls.password`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-mtls-password]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-mtls-password[`+++quarkus.temporal.connection.mtls.password+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.mtls.password+++[]
 endif::add-copy-button-to-config-props[]
@@ -1264,7 +1264,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout[`quarkus.temporal.connection.rpc-long-poll-timeout`]##
+a| [[quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-connection-rpc-long-poll-timeout[`+++quarkus.temporal.connection.rpc-long-poll-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.connection.rpc-long-poll-timeout+++[]
 endif::add-copy-button-to-config-props[]
@@ -1290,13 +1290,13 @@ h|[[quarkus-temporal_section_quarkus-temporal-workflow-retries]] [.section-name.
 h|Type
 h|Default
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-do-not-retry]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-do-not-retry[`quarkus.temporal.workflow.retries.do-not-retry`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-do-not-retry]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-do-not-retry[`+++quarkus.temporal.workflow.retries.do-not-retry+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.do-not-retry+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.do-not-retry`
+`+++quarkus.temporal.workflow."group-name".retries.do-not-retry+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.do-not-retry+++[]
 endif::add-copy-button-to-config-props[]
@@ -1316,13 +1316,13 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++[]+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-initial-interval[`quarkus.temporal.workflow.retries.initial-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-initial-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-initial-interval[`+++quarkus.temporal.workflow.retries.initial-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.initial-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.initial-interval`
+`+++quarkus.temporal.workflow."group-name".retries.initial-interval+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.initial-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1342,13 +1342,13 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++1S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-backoff-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-backoff-coefficient[`quarkus.temporal.workflow.retries.backoff-coefficient`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-backoff-coefficient]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-backoff-coefficient[`+++quarkus.temporal.workflow.retries.backoff-coefficient+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.backoff-coefficient+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.backoff-coefficient`
+`+++quarkus.temporal.workflow."group-name".retries.backoff-coefficient+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.backoff-coefficient+++[]
 endif::add-copy-button-to-config-props[]
@@ -1368,13 +1368,13 @@ endif::add-copy-button-to-env-var[]
 |double
 |`+++2.0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-set-maximum-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-set-maximum-attempts[`quarkus.temporal.workflow.retries.set-maximum-attempts`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-set-maximum-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-set-maximum-attempts[`+++quarkus.temporal.workflow.retries.set-maximum-attempts+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.set-maximum-attempts+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.set-maximum-attempts`
+`+++quarkus.temporal.workflow."group-name".retries.set-maximum-attempts+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.set-maximum-attempts+++[]
 endif::add-copy-button-to-config-props[]
@@ -1394,13 +1394,13 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++0+++`
 
-a| [[quarkus-temporal_quarkus-temporal-workflow-retries-maximum-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-maximum-interval[`quarkus.temporal.workflow.retries.maximum-interval`]##
+a| [[quarkus-temporal_quarkus-temporal-workflow-retries-maximum-interval]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-workflow-retries-maximum-interval[`+++quarkus.temporal.workflow.retries.maximum-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow.retries.maximum-interval+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.temporal.workflow."group-name".retries.maximum-interval`
+`+++quarkus.temporal.workflow."group-name".retries.maximum-interval+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.workflow."group-name".retries.maximum-interval+++[]
 endif::add-copy-button-to-config-props[]
@@ -1425,7 +1425,7 @@ h|[[quarkus-temporal_section_quarkus-temporal-worker-factory]] [.section-name.se
 h|Type
 h|Default
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-using-virtual-workflow-threads]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-using-virtual-workflow-threads[`quarkus.temporal.worker-factory.using-virtual-workflow-threads`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-using-virtual-workflow-threads]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-using-virtual-workflow-threads[`+++quarkus.temporal.worker-factory.using-virtual-workflow-threads+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.using-virtual-workflow-threads+++[]
 endif::add-copy-button-to-config-props[]
@@ -1446,7 +1446,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-max-workflow-thread-count]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-max-workflow-thread-count[`quarkus.temporal.worker-factory.max-workflow-thread-count`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-max-workflow-thread-count]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-max-workflow-thread-count[`+++quarkus.temporal.worker-factory.max-workflow-thread-count+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.max-workflow-thread-count+++[]
 endif::add-copy-button-to-config-props[]
@@ -1467,7 +1467,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++600+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-workflow-cache-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-workflow-cache-size[`quarkus.temporal.worker-factory.workflow-cache-size`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-workflow-cache-size]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-workflow-cache-size[`+++quarkus.temporal.worker-factory.workflow-cache-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.workflow-cache-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -1488,7 +1488,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++600+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-fail-on-startup-error]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-fail-on-startup-error[`quarkus.temporal.worker-factory.fail-on-startup-error`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-fail-on-startup-error]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-fail-on-startup-error[`+++quarkus.temporal.worker-factory.fail-on-startup-error+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.fail-on-startup-error+++[]
 endif::add-copy-button-to-config-props[]
@@ -1509,7 +1509,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-max-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-max-attempts[`quarkus.temporal.worker-factory.startup-max-attempts`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-max-attempts]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-max-attempts[`+++quarkus.temporal.worker-factory.startup-max-attempts+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.startup-max-attempts+++[]
 endif::add-copy-button-to-config-props[]
@@ -1530,7 +1530,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++1+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-retry-delay]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-retry-delay[`quarkus.temporal.worker-factory.startup-retry-delay`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-retry-delay]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-retry-delay[`+++quarkus.temporal.worker-factory.startup-retry-delay+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.startup-retry-delay+++[]
 endif::add-copy-button-to-config-props[]
@@ -1551,7 +1551,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-temporal_quarkus-temporal[icon:question-circle[title=More information about the Duration format]]
 |`+++2S+++`
 
-a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-background-retry-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-background-retry-enabled[`quarkus.temporal.worker-factory.startup-background-retry-enabled`]##
+a| [[quarkus-temporal_quarkus-temporal-worker-factory-startup-background-retry-enabled]] [.property-path]##link:#quarkus-temporal_quarkus-temporal-worker-factory-startup-background-retry-enabled[`+++quarkus.temporal.worker-factory.startup-background-retry-enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.temporal.worker-factory.startup-background-retry-enabled+++[]
 endif::add-copy-button-to-config-props[]

--- a/extension/deployment/pom.xml
+++ b/extension/deployment/pom.xml
@@ -45,7 +45,7 @@
         <!-- TESTING -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extension/deployment/src/main/java/io/quarkiverse/temporal/deployment/graal/grpc/GrpcCommonProcessor.java
+++ b/extension/deployment/src/main/java/io/quarkiverse/temporal/deployment/graal/grpc/GrpcCommonProcessor.java
@@ -1,9 +1,16 @@
 package io.quarkiverse.temporal.deployment.graal.grpc;
 
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 
 public class GrpcCommonProcessor {
+
+    @BuildStep
+    public IndexDependencyBuildItem indexProtobuf() {
+        // needed with reflection lookup
+        return new IndexDependencyBuildItem("com.google.protobuf", "protobuf-java");
+    }
 
     @BuildStep
     NativeImageConfigBuildItem nativeImageConfiguration() {
@@ -17,7 +24,8 @@ public class GrpcCommonProcessor {
                 .addRuntimeInitializedClass("io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder")
                 .addRuntimeInitializedClass("io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder")
                 .addRuntimeInitializedClass("io.grpc.internal.RetriableStream")
-                .addRuntimeReinitializedClass("com.google.protobuf.UnsafeUtil");
+                .addRuntimeInitializedClass("com.google.protobuf.JavaFeaturesProto")
+                .addRuntimeInitializedClass("com.google.protobuf.UnsafeUtil");
         return builder.build();
     }
 

--- a/extension/deployment/src/main/java/io/quarkiverse/temporal/deployment/graal/netty/NettyProcessor.java
+++ b/extension/deployment/src/main/java/io/quarkiverse/temporal/deployment/graal/netty/NettyProcessor.java
@@ -1,24 +1,36 @@
 package io.quarkiverse.temporal.deployment.graal.netty;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Random;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import jakarta.inject.Singleton;
 
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
 import org.jboss.logmanager.Level;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
 
+import io.grpc.netty.shaded.io.netty.channel.ChannelHandler;
+import io.grpc.netty.shaded.io.netty.channel.DefaultChannelId;
 import io.grpc.netty.shaded.io.netty.channel.EventLoopGroup;
 import io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLogger;
 import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory;
 import io.quarkiverse.temporal.graal.netty.BossEventLoopGroup;
 import io.quarkiverse.temporal.graal.netty.MainEventLoopGroup;
 import io.quarkiverse.temporal.graal.netty.runtime.EmptyByteBufStub;
+import io.quarkiverse.temporal.graal.netty.runtime.MachineIdGenerator;
 import io.quarkiverse.temporal.graal.netty.runtime.NettyRecorder;
+import io.quarkiverse.temporal.graal.netty.runtime.NettySharable;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
@@ -26,15 +38,36 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.GeneratedRuntimeSystemPropertyBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
+import io.quarkus.deployment.builditem.ModuleEnableNativeAccessBuildItem;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+import io.quarkus.deployment.builditem.PreInitRunnableBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveFieldBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
+import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
+import io.quarkus.gizmo.ClassTransformer;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
+import io.quarkus.runtime.util.JavaVersionGreaterOrEqual25;
 
 class NettyProcessor {
 
@@ -64,24 +97,85 @@ class NettyProcessor {
     }
 
     @BuildStep
-    public SystemPropertyBuildItem setNettyMachineId() {
+    public GeneratedRuntimeSystemPropertyBuildItem setNettyMachineId() {
         // we set the io.grpc.netty.shaded.io.netty.machineId system property so to prevent potential
         // slowness when generating/inferring the default machine id in io.grpc.netty.shaded.io.netty.channel.DefaultChannelId
         // implementation, which iterates over the NetworkInterfaces to determine the "best" machine id
+        return new GeneratedRuntimeSystemPropertyBuildItem("io.grpc.netty.shaded.io.netty.machineId", MachineIdGenerator.class);
+    }
 
-        // borrowed from io.grpc.netty.shaded.io.netty.util.internal.MacAddressUtil.EUI64_MAC_ADDRESS_LENGTH
-        final int EUI64_MAC_ADDRESS_LENGTH = 8;
-        final byte[] machineIdBytes = new byte[EUI64_MAC_ADDRESS_LENGTH];
-        new Random().nextBytes(machineIdBytes);
-        final String nettyMachineId = io.grpc.netty.shaded.io.netty.util.internal.MacAddressUtil.formatAddress(machineIdBytes);
-        return new SystemPropertyBuildItem("io.grpc.netty.shaded.io.netty.machineId", nettyMachineId);
+    @BuildStep
+    public SystemPropertyBuildItem disableFinalizers() {
+        return new SystemPropertyBuildItem(
+                "io.grpc.netty.shaded.io.netty.allocator.disableCacheFinalizersForFastThreadLocalThreads", "true");
+    }
+
+    @BuildStep
+    public PreInitRunnableBuildItem preInitPlatformDependent() {
+        // initialize PlatformDependent as a pre-init task as it's quite slow
+        return PreInitRunnableBuildItem.initializeClass(PlatformDependent.class.getName(),
+                PreInitRunnableBuildItem.DEFAULT_PRIORITY - 50);
+    }
+
+    /**
+     * <a href="https://openjdk.org/jeps/471">JEP 471</a> locks down access to sun.misc.Unsafe, Netty needs to adapt
+     * to this to maintain its efficiency. As this work progresses in upstream Netty to handle this better automatically, we can
+     * already apply the following recommendations by the Netty team. See also
+     * <a href="https://github.com/quarkusio/quarkus/issues/39907">#39907</a> and
+     * <a href="https://netty.io/wiki/java-24-and-sun.misc.unsafe.html">Java 24 and sun.misc.unsafe</a>.
+     * </p>
+     * Unfortunately, "--sun-misc-unsafe-memory-access=allow" should also be set for Java runtime, but it can't be applied
+     * automatically as the JAR Manifest format doesn't allow setting such an option.
+     */
+    @BuildStep(onlyIf = JavaVersionGreaterOrEqual25.class)
+    NativeImageConfigBuildItem build25Specific(
+            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
+            BuildProducer<ReflectiveFieldBuildItem> reflectiveFields,
+            BuildProducer<ModuleOpenBuildItem> moduleOpenBuildItem) {
+
+        reflectiveMethods.produce(
+                new ReflectiveMethodBuildItem("Reflectively accessed through Netty's PlatformDependent0.",
+                        "jdk.internal.misc.Unsafe", "allocateUninitializedArray",
+                        new String[] { Class.class.getName(), int.class.getName() }));
+
+        reflectiveFields.produce(
+                new ReflectiveFieldBuildItem("Reflectively accessed through Netty's PlatformDependent0.",
+                        "java.nio.Bits", "UNSAFE_SET_THRESHOLD"));
+
+        // Enables Netty's PlatformDependent0 and PlatformDependent to access java.nio, e.g. java.nio.Bits
+        // It's potentially problematic regarding build-time and run-time inited JDK parts.
+        moduleOpenBuildItem.produce(
+                new ModuleOpenBuildItem("java.base", "io.grpc.netty.shaded.io.netty.common", "java.nio", "jdk.internal.misc"));
+
+        final NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder()
+                .addNativeImageSystemProperty("io.grpc.netty.shaded.io.netty.tryReflectionSetAccessible", "true")
+                .addNativeImageSystemProperty("io.grpc.netty.shaded.io.netty.noUnsafe", "false");
+        return builder.build();
     }
 
     @BuildStep
     NativeImageConfigBuildItem build(
             NettyBuildTimeConfig config,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
+            BuildProducer<ReflectiveFieldBuildItem> reflectiveFields,
             List<MinNettyAllocatorMaxOrderBuildItem> minMaxOrderBuildItems) {
+
+        reflectiveMethods.produce(
+                new ReflectiveMethodBuildItem("Reflectively accessed through PlatformDependent0's static initializer",
+                        "jdk.internal.misc.Unsafe", "getUnsafe", new String[0]));
+
+        // in JDK >= 21 the constructor has `long, long` signature
+        reflectiveMethods.produce(
+                new ReflectiveMethodBuildItem("Reflectively accessed through PlatformDependent0's static initializer",
+                        "java.nio.DirectByteBuffer", "<init>", new String[] { long.class.getName(), long.class.getName() }));
+
+        reflectiveFields.produce(
+                new ReflectiveFieldBuildItem("Reflectively accessed through PlatformDependent0's static initializer",
+                        "java.nio.Bits", "UNALIGNED"));
+        reflectiveFields.produce(
+                new ReflectiveFieldBuildItem("Reflectively accessed through PlatformDependent0's static initializer",
+                        "java.nio.Bits", "MAX_MEMORY"));
 
         reflectiveClass
                 .produce(ReflectiveClassBuildItem.builder("io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel")
@@ -226,22 +320,26 @@ class NettyProcessor {
         // - io.grpc.netty.shaded.io.netty.bitMode
         // - sun.arch.data.model
         // - com.ibm.vm.bitmode
-        builder.addRuntimeReinitializedClass("io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent")
+        builder.addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent")
                 // Similarly for properties:
                 // - io.grpc.netty.shaded.io.netty.noUnsafe
                 // - sun.misc.unsafe.memory.access
                 // - io.grpc.netty.shaded.io.netty.tryUnsafe
                 // - org.jboss.netty.tryUnsafe
                 // - io.grpc.netty.shaded.io.netty.tryReflectionSetAccessible
-                .addRuntimeReinitializedClass("io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0");
+                .addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0")
+                // Runtime initialize classes to allow netty to use the field offset for testing if unsafe is available or not
+                // See https://github.com/quarkusio/quarkus/issues/47903#issuecomment-2890924970
+                .addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.util.AbstractReferenceCounted")
+                .addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.buffer.AbstractReferenceCountedByteBuf");
 
         if (QuarkusClassLoader.isClassPresentAtRuntime("io.grpc.netty.shaded.io.netty.buffer.UnpooledByteBufAllocator")) {
             // Runtime initialize due to the use of the io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent class
-            builder.addRuntimeReinitializedClass("io.grpc.netty.shaded.io.netty.buffer.UnpooledByteBufAllocator")
-                    .addRuntimeReinitializedClass("io.grpc.netty.shaded.io.netty.buffer.Unpooled")
+            builder.addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.buffer.UnpooledByteBufAllocator")
+                    .addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.buffer.Unpooled")
                     // Runtime initialize due to dependency on io.grpc.netty.shaded.io.netty.buffer.Unpooled
-                    .addRuntimeReinitializedClass("io.grpc.netty.shaded.io.netty.handler.codec.http.HttpObjectAggregator")
-                    .addRuntimeReinitializedClass("io.grpc.netty.shaded.io.netty.handler.codec.ReplayingDecoderByteBuf")
+                    .addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.handler.codec.http.HttpObjectAggregator")
+                    .addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.handler.codec.ReplayingDecoderByteBuf")
                     // Runtime initialize to avoid embedding quite a few Strings in the image heap
                     .addRuntimeInitializedClass("io.grpc.netty.shaded.io.netty.buffer.ByteBufUtil$HexUtil")
                     // Runtime initialize due to the use of the io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent class in the
@@ -272,22 +370,13 @@ class NettyProcessor {
             if (QuarkusClassLoader
                     .isClassPresentAtRuntime("org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartFormUpload")) {
                 // Runtime initialize due to dependency on io.grpc.netty.shaded.io.netty.buffer.Unpooled
-                builder.addRuntimeReinitializedClass(
+                builder.addRuntimeInitializedClass(
                         "org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartFormUpload");
             }
         }
 
         return builder //TODO: make configurable
                 .build();
-    }
-
-    @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
-    public void eagerlyInitClass(NettyRecorder recorder) {
-        //see https://github.com/quarkusio/quarkus/issues/3663
-        //this class is slow to initialize, we make sure that we do it eagerly
-        //before it blocks the IO thread and causes a warning
-        recorder.eagerlyInitChannelId();
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -337,8 +426,8 @@ class NettyProcessor {
     }
 
     @BuildStep
-    public RuntimeReinitializedClassBuildItem reinitScheduledFutureTask() {
-        return new RuntimeReinitializedClassBuildItem(
+    public RuntimeInitializedClassBuildItem reinitScheduledFutureTask() {
+        return new RuntimeInitializedClassBuildItem(
                 "io.quarkiverse.temporal.graal.netty.runtime.graal.Holder_io_netty_util_concurrent_ScheduledFutureTask");
     }
 
@@ -402,5 +491,572 @@ class NettyProcessor {
         }
 
         return Integer.toString(result);
+    }
+
+    /**
+     * Transforms {@code io.grpc.netty.shaded.io.netty.util.internal.CleanerJava9} to take advantage of the fact that we know we
+     * are in Java 17+
+     * Generated bytecode structure:
+     *
+     * <pre>{@code
+     * final class CleanerJava9 implements Cleaner {
+     *     private static final InternalLogger logger = InternalLoggerFactory.getInstance(CleanerJava9.class);
+     *     private static final boolean SUPPORTED;
+     *
+     *     private static void freeDirectBufferPrivileged(ByteBuffer buffer) {
+     *         Exception error = AccessController.doPrivileged(new PrivilegedAction(buffer));
+     *         if (error != null) {
+     *             PlatformDependent0.throwException(error);
+     *         }
+     *     }
+     *
+     *     static {
+     *         boolean var2 = false;
+     *         Throwable var3 = null;
+     *         if (!PlatformDependent0.hasUnsafe()) {
+     *             var3 = new UnsupportedOperationException("sun.misc.Unsafe unavailable");
+     *         } else {
+     *             try {
+     *                 ByteBuffer var0 = ByteBuffer.allocateDirect(1);
+     *                 PlatformDependent0.UNSAFE.invokeCleaner(var0);
+     *                 var2 = true;
+     *             } catch (Throwable var4) {
+     *                 var3 = var4;
+     *             }
+     *         }
+     *
+     *         SUPPORTED = var2;
+     *         if (var3 != null) {
+     *             logger.debug("java.nio.ByteBuffer.cleaner(): unavailable", var3);
+     *         } else {
+     *             logger.debug("java.nio.ByteBuffer.cleaner(): available");
+     *         }
+     *     }
+     *
+     *     public void freeDirectBuffer(ByteBuffer var1) {
+     *         if (System.getSecurityManager() != null) {
+     *             freeDirectBufferPrivileged(var1);
+     *         } else {
+     *             PlatformDependent0.UNSAFE.invokeCleaner(var1);
+     *         }
+     *     }
+     *
+     *     public static boolean isSupported() {
+     *         return SUPPORTED;
+     *     }
+     * }
+     * }</pre>
+     */
+    @BuildStep
+    BytecodeTransformerBuildItem transformCleanerJava9() {
+        String className = "io.grpc.netty.shaded.io.netty.util.internal.CleanerJava9";
+        return new BytecodeTransformerBuildItem.Builder().setClassToTransform(className)
+                .setCacheable(true).setVisitorFunction(
+                        new BiFunction<>() {
+                            @Override
+                            public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                                FieldDescriptor supportedFieldDescriptor = FieldDescriptor
+                                        .of(className, "SUPPORTED", boolean.class);
+
+                                ClassTransformer transformer = new ClassTransformer(className);
+
+                                transformer.addField(supportedFieldDescriptor)
+                                        .setModifiers(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL);
+                                transformer.removeField("INVOKE_CLEANER", Method.class);
+
+                                {
+                                    MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(className, "<clinit>",
+                                            void.class);
+                                    transformer.removeMethod(methodDescriptor);
+
+                                    {
+                                        MethodCreator clinitMethod = transformer.addMethod(methodDescriptor).setModifiers(
+                                                Modifier.PUBLIC | Modifier.STATIC);
+
+                                        // Initialize logger
+                                        ResultHandle cleanerClass = clinitMethod.loadClass(className);
+                                        ResultHandle loggerInstance = clinitMethod.invokeStaticMethod(
+                                                MethodDescriptor.ofMethod(
+                                                        "io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory",
+                                                        "getInstance",
+                                                        InternalLogger.class.getName(),
+                                                        Class.class),
+                                                cleanerClass);
+                                        FieldDescriptor loggerFieldDescriptor = FieldDescriptor.of(
+                                                className, "logger",
+                                                InternalLogger.class.getName());
+                                        clinitMethod.writeStaticField(loggerFieldDescriptor, loggerInstance);
+
+                                        // Initialize SUPPORTED
+                                        AssignableResultHandle supportedVar = clinitMethod.createVariable(boolean.class);
+                                        clinitMethod.assign(supportedVar, clinitMethod.load(false));
+                                        AssignableResultHandle errorVar = clinitMethod.createVariable(Throwable.class);
+                                        clinitMethod.assign(errorVar, clinitMethod.loadNull());
+
+                                        // Check if Unsafe is available
+                                        ResultHandle hasUnsafe = clinitMethod.invokeStaticMethod(
+                                                MethodDescriptor.ofMethod(
+                                                        "io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0",
+                                                        "hasUnsafe",
+                                                        boolean.class));
+
+                                        BranchResult hasUnsafeResult = clinitMethod.ifTrue(hasUnsafe);
+                                        BytecodeCreator hasUnsafeTrueBranch = hasUnsafeResult.trueBranch();
+
+                                        // Try block
+                                        {
+                                            TryBlock tryBlock = hasUnsafeTrueBranch.tryBlock();
+
+                                            // ByteBuffer buffer = ByteBuffer.allocateDirect(1);
+                                            ResultHandle buffer = tryBlock.invokeStaticMethod(
+                                                    MethodDescriptor.ofMethod(ByteBuffer.class, "allocateDirect",
+                                                            ByteBuffer.class,
+                                                            int.class),
+                                                    tryBlock.load(1));
+
+                                            // PlatformDependent0.UNSAFE.invokeCleaner(buffer);
+                                            ResultHandle unsafe = tryBlock.readStaticField(
+                                                    FieldDescriptor.of(
+                                                            "io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0",
+                                                            "UNSAFE",
+                                                            "sun.misc.Unsafe"));
+                                            tryBlock.invokeVirtualMethod(
+                                                    MethodDescriptor.ofMethod("sun.misc.Unsafe",
+                                                            "invokeCleaner",
+                                                            void.class,
+                                                            ByteBuffer.class),
+                                                    unsafe,
+                                                    buffer);
+
+                                            tryBlock.assign(supportedVar, tryBlock.load(true));
+
+                                            // Catch block
+                                            CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+                                            catchBlock.assign(errorVar, catchBlock.getCaughtException());
+                                        }
+
+                                        // Handle else branch (Unsafe unavailable)
+                                        BytecodeCreator hasUnsafeFalseBranch = hasUnsafeResult.falseBranch();
+                                        ResultHandle unsupportedEx = hasUnsafeFalseBranch.newInstance(
+                                                MethodDescriptor.ofConstructor(UnsupportedOperationException.class,
+                                                        String.class),
+                                                hasUnsafeFalseBranch.load("sun.misc.Unsafe unavailable"));
+                                        hasUnsafeFalseBranch.assign(errorVar, unsupportedEx);
+
+                                        // Write SUPPORTED field
+                                        clinitMethod.writeStaticField(supportedFieldDescriptor, supportedVar);
+
+                                        // Log the result
+
+                                        // if (error == null) {
+                                        //   logger.debug("java.nio.ByteBuffer.cleaner(): available");
+                                        // }
+                                        BranchResult errorCheck = clinitMethod.ifNull(errorVar);
+                                        BytecodeCreator errorNull = errorCheck.trueBranch();
+                                        errorNull.invokeInterfaceMethod(
+                                                MethodDescriptor.ofMethod(
+                                                        "io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLogger",
+                                                        "debug",
+                                                        void.class,
+                                                        String.class),
+                                                errorNull.readStaticField(loggerFieldDescriptor),
+                                                errorNull.load("java.nio.ByteBuffer.cleaner(): available"));
+
+                                        // else {
+                                        //   logger.debug("java.nio.ByteBuffer.cleaner(): unavailable", error);
+                                        // }
+                                        BytecodeCreator errorNotNull = errorCheck.falseBranch();
+                                        errorNotNull.invokeInterfaceMethod(
+                                                MethodDescriptor.ofMethod(
+                                                        "io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLogger",
+                                                        "debug",
+                                                        void.class,
+                                                        String.class,
+                                                        Throwable.class),
+                                                errorNotNull.readStaticField(loggerFieldDescriptor),
+                                                errorNotNull.load("java.nio.ByteBuffer.cleaner(): unavailable"),
+                                                errorVar);
+
+                                        clinitMethod.returnValue(null);
+                                    }
+                                }
+
+                                {
+                                    MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(className, "isSupported",
+                                            boolean.class);
+                                    transformer.removeMethod(methodDescriptor);
+                                    MethodCreator isSupportedMethod = transformer.addMethod(methodDescriptor);
+                                    isSupportedMethod.setModifiers(Modifier.PUBLIC | Modifier.STATIC);
+                                    isSupportedMethod.returnValue(isSupportedMethod.readStaticField(supportedFieldDescriptor));
+                                }
+
+                                {
+                                    MethodDescriptor freeDirectBufferDescriptor = MethodDescriptor.ofMethod(className,
+                                            "freeDirectBuffer", void.class, ByteBuffer.class);
+                                    transformer.removeMethod(freeDirectBufferDescriptor);
+                                    MethodCreator freeDirectBufferMethod = transformer.addMethod(freeDirectBufferDescriptor);
+                                    freeDirectBufferMethod.setModifiers(Opcodes.ACC_PUBLIC);
+
+                                    ResultHandle bufferParam = freeDirectBufferMethod.getMethodParam(0);
+
+                                    // if (System.getSecurityManager() == null)
+                                    ResultHandle securityManager = freeDirectBufferMethod.invokeStaticMethod(
+                                            MethodDescriptor.ofMethod(System.class, "getSecurityManager",
+                                                    SecurityManager.class));
+
+                                    BranchResult securityCheck = freeDirectBufferMethod.ifNull(securityManager);
+
+                                    // True branch: No security manager - direct call
+                                    BytecodeCreator noSecurityBranch = securityCheck.trueBranch();
+
+                                    // PlatformDependent0.UNSAFE.invokeCleaner(buffer);
+                                    ResultHandle unsafe = noSecurityBranch.readStaticField(
+                                            FieldDescriptor.of("io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0",
+                                                    "UNSAFE",
+                                                    "sun.misc.Unsafe"));
+                                    noSecurityBranch.invokeVirtualMethod(
+                                            MethodDescriptor.ofMethod("sun.misc.Unsafe",
+                                                    "invokeCleaner",
+                                                    void.class,
+                                                    ByteBuffer.class),
+                                            unsafe,
+                                            bufferParam);
+
+                                    // False branch: With security manager - call privileged method
+                                    BytecodeCreator withSecurityBranch = securityCheck.falseBranch();
+
+                                    // freeDirectBufferPrivileged(buffer);
+                                    withSecurityBranch.invokeStaticMethod(
+                                            MethodDescriptor.ofMethod(
+                                                    "io.grpc.netty.shaded.io.netty.util.internal.CleanerJava9",
+                                                    "freeDirectBufferPrivileged",
+                                                    void.class,
+                                                    ByteBuffer.class),
+                                            bufferParam);
+
+                                    // Return from method (void)
+                                    freeDirectBufferMethod.returnValue(null);
+                                }
+
+                                {
+                                    transformer.removeMethod("access$000", Method.class);
+                                }
+
+                                return transformer.applyTo(classVisitor);
+                            }
+                        })
+                .build();
+    }
+
+    /**
+     * When the application targets Java 21+, then we can convert
+     * {@code io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0} to depend
+     * explicitly on Virtual Threads instead of Netty needing to use reflection (that has a noticeable impact on startup).
+     * The change makes the {@code IS_VIRTUAL_THREAD_METHOD} and {@code BASE_VIRTUAL_THREAD_CLASS} fields {@code null} while
+     * also
+     * converting the {@code isVirtualThread} method to:
+     *
+     * <pre>{@code
+     * static boolean isVirtualThread() {
+     *     return thread != null && thread.isVirtual();
+     * }
+     * }</pre>
+     *
+     * The reason we don't remove the aforementioned fields is that to do that we would have to transform the class loading
+     * initialization method,
+     * which would be to brittle.
+     */
+    @BuildStep
+    void transformPlatformDependent0(CompiledJavaVersionBuildItem compiledJavaVersion,
+            BuildProducer<BytecodeTransformerBuildItem> producer) {
+        if (compiledJavaVersion.getJavaVersion().isJava21OrHigher() != CompiledJavaVersionBuildItem.JavaVersion.Status.TRUE) {
+            return;
+        }
+        String className = "io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0";
+        producer.produce(new BytecodeTransformerBuildItem.Builder().setClassToTransform(className)
+                .setCacheable(true).setVisitorFunction(
+                        new BiFunction<>() {
+                            @Override
+                            public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                                ClassTransformer transformer = new ClassTransformer(className);
+
+                                {
+                                    MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(className,
+                                            "getIsVirtualThreadMethod",
+                                            Method.class);
+                                    transformer.removeMethod(methodDescriptor);
+                                    MethodCreator getIsVirtualThreadMethod = transformer.addMethod(methodDescriptor)
+                                            .setModifiers(Modifier.STATIC | Modifier.PRIVATE);
+                                    getIsVirtualThreadMethod.returnValue(getIsVirtualThreadMethod.loadNull());
+                                }
+
+                                {
+                                    MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(className,
+                                            "getBaseVirtualThreadClass",
+                                            Class.class);
+                                    transformer.removeMethod(methodDescriptor);
+                                    MethodCreator getBaseVirtualThreadClassMethod = transformer.addMethod(methodDescriptor)
+                                            .setModifiers(Modifier.STATIC | Modifier.PRIVATE);
+                                    getBaseVirtualThreadClassMethod.returnValue(getBaseVirtualThreadClassMethod.loadNull());
+                                }
+
+                                {
+                                    MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(className, "isVirtualThread",
+                                            boolean.class, Thread.class);
+                                    transformer.removeMethod(methodDescriptor);
+
+                                    MethodCreator isVirtualThreadMethod = transformer.addMethod(methodDescriptor)
+                                            .setModifiers(Modifier.STATIC);
+
+                                    // Get the thread parameter
+                                    ResultHandle threadParam = isVirtualThreadMethod.getMethodParam(0);
+
+                                    // Check if thread is null
+                                    BranchResult nullCheck = isVirtualThreadMethod.ifNull(threadParam);
+
+                                    // If null, return false
+                                    nullCheck.trueBranch().returnValue(nullCheck.trueBranch().load(false));
+
+                                    // If not null, call thread.isVirtual()
+                                    MethodDescriptor isVirtualMethod = MethodDescriptor.ofMethod(
+                                            Thread.class,
+                                            "isVirtual",
+                                            boolean.class);
+                                    ResultHandle isVirtualResult = nullCheck.falseBranch().invokeVirtualMethod(
+                                            isVirtualMethod,
+                                            threadParam);
+
+                                    // Return the result
+                                    nullCheck.falseBranch().returnValue(isVirtualResult);
+                                }
+
+                                return transformer.applyTo(classVisitor);
+                            }
+                        })
+                .build());
+    }
+
+    /**
+     * Rewrites {@code DefaultChannelId#processHandlePid(ClassLoader)} to avoid reflection as we know we are using Java 17+.
+     * <p>
+     * Generates:
+     *
+     * <pre>
+     * public static int processHandlePid(ClassLoader classLoader) {
+     *     int resultVar;
+     *     try {
+     *         ProcessHandle processHandle = ProcessHandle.current();
+     *
+     *         long pid = processHandle.pid();
+     *
+     *         long maxInt = 2147483647L;
+     *         int cmp = Long.compare(pid, maxInt);
+     *
+     *         if (cmp > 0) {
+     *             resultVar = -1;
+     *         } else {
+     *             resultVar = (int) pid;
+     *         }
+     *     } catch (Exception e) {
+     *         logger.debug("Could not invoke ProcessHandle.current().pid();", e);
+     *         resultVar = -1;
+     *     }
+     *
+     *     return resultVar;
+     * }
+     * </pre>
+     */
+    @BuildStep
+    void transformDefaultChannelId(BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformers) {
+        // we know we are using Java 17+ so we can always apply this transformation
+
+        String className = DefaultChannelId.class.getName();
+
+        bytecodeTransformers.produce(
+                new BytecodeTransformerBuildItem.Builder()
+                        .setClassToTransform(className)
+                        .setCacheable(true)
+                        .setVisitorFunction((s, classVisitor) -> {
+                            ClassVisitor updateBytecodeVersion = new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+                                @Override
+                                public void visit(int version, int access, String name, String signature, String superName,
+                                        String[] interfaces) {
+                                    // bump bytecode version to at least 52 as we need it to be able to call static methods on interfaces with Gizmo
+                                    super.visit(Math.max(version, 52), access, name, signature, superName, interfaces);
+                                }
+                            };
+
+                            ClassTransformer transformer = new ClassTransformer(className);
+
+                            MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(
+                                    className,
+                                    "processHandlePid",
+                                    int.class,
+                                    ClassLoader.class);
+
+                            transformer.removeMethod(methodDescriptor);
+
+                            MethodCreator method = transformer.addMethod(methodDescriptor)
+                                    .setModifiers(Modifier.STATIC);
+
+                            AssignableResultHandle resultVar = method.createVariable(int.class);
+
+                            TryBlock tryBlock = method.tryBlock();
+
+                            ResultHandle processHandle = tryBlock.invokeStaticInterfaceMethod(
+                                    MethodDescriptor.ofMethod(
+                                            ProcessHandle.class,
+                                            "current",
+                                            ProcessHandle.class));
+
+                            ResultHandle pid = tryBlock.invokeInterfaceMethod(
+                                    MethodDescriptor.ofMethod(
+                                            ProcessHandle.class,
+                                            "pid",
+                                            long.class),
+                                    processHandle);
+
+                            ResultHandle maxInt = tryBlock.load((long) Integer.MAX_VALUE);
+                            ResultHandle cmp = tryBlock.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(
+                                            Long.class,
+                                            "compare",
+                                            int.class,
+                                            long.class,
+                                            long.class),
+                                    pid,
+                                    maxInt);
+
+                            BranchResult branchResult = tryBlock.ifGreaterThanZero(cmp);
+
+                            // pid > Integer.MAX_VALUE, assign -1
+                            BytecodeCreator outOfRangeBranch = branchResult.trueBranch();
+                            outOfRangeBranch.assign(resultVar, outOfRangeBranch.load(-1));
+
+                            // pid <= Integer.MAX_VALUE, convert long to int
+                            BytecodeCreator inRangeBranch = branchResult.falseBranch();
+                            inRangeBranch.assign(resultVar, inRangeBranch.convertPrimitive(pid, int.class));
+
+                            CatchBlockCreator catchBlock = tryBlock.addCatch(Exception.class);
+                            // logger.debug("Could not invoke ProcessHandle.current().pid();", e);
+                            catchBlock.invokeInterfaceMethod(
+                                    MethodDescriptor.ofMethod(
+                                            io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLogger.class,
+                                            "debug",
+                                            void.class,
+                                            String.class,
+                                            Throwable.class),
+                                    catchBlock.readStaticField(
+                                            FieldDescriptor.of(className, "logger",
+                                                    io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLogger.class)),
+                                    catchBlock.load("Could not invoke ProcessHandle.current().pid();"),
+                                    catchBlock.getCaughtException());
+                            catchBlock.assign(resultVar, catchBlock.load(-1));
+
+                            method.returnValue(resultVar);
+
+                            return transformer.applyTo(updateBytecodeVersion);
+                        })
+                        .build());
+    }
+
+    @BuildStep
+    void nativeTransportsEnableNativeAccess(BuildProducer<ModuleEnableNativeAccessBuildItem> nativeAccess) {
+        if (QuarkusClassLoader.isClassPresentAtRuntime("io.grpc.netty.shaded.io.netty.channel.epoll.EpollMode")) {
+            nativeAccess
+                    .produce(new ModuleEnableNativeAccessBuildItem("io.grpc.netty.shaded.io.netty.transport.classes.epoll"));
+        }
+        if (QuarkusClassLoader.isClassPresentAtRuntime("io.grpc.netty.shaded.io.netty.channel.kqueue.AcceptFilter")) {
+            nativeAccess
+                    .produce(new ModuleEnableNativeAccessBuildItem("io.grpc.netty.shaded.io.netty.transport.classes.kqueue"));
+        }
+    }
+
+    @BuildStep
+    void indexTransports(BuildProducer<IndexDependencyBuildItem> producer) {
+        producer.produce(new IndexDependencyBuildItem("io.grpc.netty.shaded.io.netty", "netty-transport"));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void transformIsSharable(CombinedIndexBuildItem indexBuildItem,
+            NettyRecorder recorder,
+            BuildProducer<BytecodeTransformerBuildItem> producer) {
+        IndexView index = indexBuildItem.getIndex();
+
+        // add the NettySharable marker to each class that is annotated with @Sharable
+        index.getAnnotations(ChannelHandler.Sharable.class).forEach(ai -> {
+            if (ai.target().kind() != AnnotationTarget.Kind.CLASS) {
+                return;
+            }
+
+            String className = ai.target().asClass().name().toString();
+            producer.produce(new BytecodeTransformerBuildItem.Builder().setClassToTransform(className)
+                    .setCacheable(true).setVisitorFunction(new AddSharableVisitorFunction(className)).build());
+        });
+
+        /*
+         * Transform ChannelHandlerAdapter to:
+         *
+         * public boolean isSharable() {
+         * if (this instanceof NettySharable) {
+         * return true;
+         * }
+         * return this.isSharable0();
+         * }
+         *
+         * where `isSharable0` is the old `isSharable` method of ChannelHandlerAdapter
+         */
+        String classAdapterClassName = "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerAdapter";
+        producer.produce(new BytecodeTransformerBuildItem.Builder().setClassToTransform(classAdapterClassName)
+                .setCacheable(true).setVisitorFunction(new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        ClassTransformer transformer = new ClassTransformer(classAdapterClassName);
+
+                        MethodDescriptor isSharableMethod = MethodDescriptor.ofMethod(classAdapterClassName, "isSharable",
+                                boolean.class);
+
+                        // old isSharable becomes isSharable0
+                        transformer.modifyMethod(isSharableMethod).rename("isSharable0");
+
+                        // new isSharable method
+                        {
+                            MethodDescriptor isSharable0Method = MethodDescriptor.ofMethod(classAdapterClassName, "isSharable0",
+                                    boolean.class);
+
+                            MethodCreator mc = transformer.addMethod(isSharableMethod);
+
+                            // clazz instanceof NettySharable
+                            ResultHandle isInstanceOf = mc.instanceOf(mc.getThis(), NettySharable.class);
+
+                            // if (instanceof) return true; else call isSharable0
+                            BytecodeCreator trueBranch = mc.ifNonZero(isInstanceOf).trueBranch();
+                            trueBranch.returnValue(trueBranch.load(true));
+                            ResultHandle result = mc.invokeVirtualMethod(isSharable0Method, mc.getThis());
+
+                            mc.returnValue(result);
+                        }
+
+                        return transformer.applyTo(classVisitor);
+                    }
+                }).build());
+
+    }
+
+    private static class AddSharableVisitorFunction implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+        private final String className;
+
+        private AddSharableVisitorFunction(String className) {
+            this.className = className;
+        }
+
+        @Override
+        public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+            ClassTransformer transformer = new ClassTransformer(className);
+            transformer.addInterface(NettySharable.class);
+            return transformer.applyTo(classVisitor);
+        }
     }
 }

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/grpc/runtime/graal/GrpcNettySubstitutions.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/grpc/runtime/graal/GrpcNettySubstitutions.java
@@ -14,8 +14,10 @@ import io.grpc.NameResolver;
 import io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
+import io.smallrye.common.annotation.SuppressForbidden;
 
 @TargetClass(className = "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators")
+@SuppressForbidden(reason = "Use original class logging implementation")
 final class Target_io_grpc_netty_ProtocolNegotiators {
 
     @Substitute

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/MachineIdGenerator.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/MachineIdGenerator.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.temporal.graal.netty.runtime;
+
+import java.util.Random;
+import java.util.function.Supplier;
+
+public final class MachineIdGenerator implements Supplier<String> {
+
+    /**
+     * We have our own implementation to generate the io.grpc.netty.shaded.io.netty.machineId to prevent potential
+     * slowness when generating/inferring the default machine id in io.grpc.netty.shaded.io.netty.channel.DefaultChannelId
+     * implementation, which iterates over the NetworkInterfaces to determine the "best" machine id
+     */
+    public String get() {
+        // borrowed from io.grpc.netty.shaded.io.netty.util.internal.MacAddressUtil.EUI64_MAC_ADDRESS_LENGTH
+        final int EUI64_MAC_ADDRESS_LENGTH = 8;
+        final byte[] machineIdBytes = new byte[EUI64_MAC_ADDRESS_LENGTH];
+        new Random().nextBytes(machineIdBytes);
+        return io.grpc.netty.shaded.io.netty.util.internal.MacAddressUtil.formatAddress(machineIdBytes);
+    }
+}

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/NettyRecorder.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/NettyRecorder.java
@@ -2,38 +2,12 @@ package io.quarkiverse.temporal.graal.netty.runtime;
 
 import java.util.function.Supplier;
 
-import org.jboss.logging.Logger;
-
-import io.grpc.netty.shaded.io.netty.channel.DefaultChannelId;
 import io.grpc.netty.shaded.io.netty.channel.EventLoopGroup;
 import io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class NettyRecorder {
-
-    private static final Logger log = Logger.getLogger(NettyRecorder.class);
-
-    // TODO: Remove this method (maybe in 1.6.x of Quarkus or later) if there are no user reports
-    // of the WARN message issued from this method. See comments in https://github.com/quarkusio/quarkus/pull/9246
-    // for details
-    public void eagerlyInitChannelId() {
-        //this class is slow to init and can block the IO thread and cause a warning
-        //we init it from a throwaway thread to stop this
-        //we do it from another thread so as not to affect start time
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                DefaultChannelId.newInstance();
-                if (System.currentTimeMillis() - start > 1000) {
-                    log.warn("Netty DefaultChannelId initialization (with io.grpc.netty.shaded.io.netty.machineId" +
-                            " system property set to " + System.getProperty("io.grpc.netty.shaded.io.netty.machineId")
-                            + ") took more than a second");
-                }
-            }
-        }).start();
-    }
 
     public Supplier<EventLoopGroup> createEventLoop(int nThreads) {
         return new Supplier<EventLoopGroup>() {

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/NettySharable.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/NettySharable.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.temporal.graal.netty.runtime;
+
+import io.grpc.netty.shaded.io.netty.channel.ChannelHandlerAdapter;
+
+/**
+ * Custom marker interface used to do faster {@link ChannelHandlerAdapter#isSharable()} checks as an interface instanceof
+ * is much faster than looking up an annotation
+ */
+public interface NettySharable {
+}

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/graal/NettySubstitutions.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/graal/NettySubstitutions.java
@@ -21,9 +21,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.BooleanSupplier;
 
 import javax.crypto.NoSuchPaddingException;
@@ -173,7 +171,8 @@ final class Target_io_netty_handler_ssl_JdkSslServerContext {
             KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
             ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout,
             ClientAuth clientAuth, String[] protocols, boolean startTls,
-            SecureRandom secureRandom, String keyStore) throws SSLException {
+            SecureRandom secureRandom, String keyStore, Target_io_netty_handler_ssl_ResumptionController resumptionController)
+            throws SSLException {
     }
 }
 
@@ -181,12 +180,13 @@ final class Target_io_netty_handler_ssl_JdkSslServerContext {
 final class Target_io_netty_handler_ssl_JdkSslClientContext {
 
     @Alias
-    Target_io_netty_handler_ssl_JdkSslClientContext(Provider sslContextProvider, X509Certificate[] trustCertCollection,
-            TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
-            String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
-            CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
-            long sessionCacheSize, long sessionTimeout, SecureRandom secureRandom,
-            String keyStoreType) throws SSLException {
+    Target_io_netty_handler_ssl_JdkSslClientContext(Provider sslContextProvider,
+            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
+            KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            ApplicationProtocolConfig apn, String[] protocols, long sessionCacheSize, long sessionTimeout,
+            SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
+            Target_io_netty_handler_ssl_ResumptionController resumptionController) throws SSLException {
     }
 }
 
@@ -222,43 +222,55 @@ final class Target_io_netty_handler_ssl_JdkAlpnSslEngine {
     }
 }
 
+@TargetClass(className = "io.grpc.netty.shaded.io.netty.handler.ssl.ResumptionController")
+final class Target_io_netty_handler_ssl_ResumptionController {
+
+    @Alias
+    Target_io_netty_handler_ssl_ResumptionController() {
+
+    }
+}
+
 @TargetClass(className = "io.grpc.netty.shaded.io.netty.handler.ssl.SslContext")
 final class Target_io_netty_handler_ssl_SslContext {
 
     @Substitute
-    static SslContext newServerContextInternal(SslProvider provider, Provider sslContextProvider,
+    static SslContext newServerContextInternal(SslProvider provider,
+            Provider sslContextProvider,
             X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
-            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
-            KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
-            CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
-            long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth,
-            String[] protocols, boolean startTls, boolean enableOcsp,
-            SecureRandom secureRandom, String keyStoreType,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+            long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
+            boolean enableOcsp, SecureRandom secureRandom, String keyStoreType,
             Map.Entry<SslContextOption<?>, Object>... ctxOptions) throws SSLException {
         if (enableOcsp) {
             throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
         }
+        Target_io_netty_handler_ssl_ResumptionController resumptionController = new Target_io_netty_handler_ssl_ResumptionController();
         return (SslContext) (Object) new Target_io_netty_handler_ssl_JdkSslServerContext(sslContextProvider,
                 trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
                 keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                clientAuth, protocols, startTls, secureRandom, keyStoreType);
+                clientAuth, protocols, startTls, secureRandom, keyStoreType, resumptionController);
     }
 
     @Substitute
-    static SslContext newClientContextInternal(SslProvider provider, Provider sslContextProvider,
-            X509Certificate[] trustCert,
-            TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
-            KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
-            ApplicationProtocolConfig apn, String[] protocols, long sessionCacheSize, long sessionTimeout,
-            boolean enableOcsp, SecureRandom secureRandom,
-            String keyStoreType, Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
+    static SslContext newClientContextInternal(SslProvider provider,
+            Provider sslContextProvider,
+            X509Certificate[] trustCert, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+            long sessionCacheSize, long sessionTimeout, boolean enableOcsp,
+            SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
+            Map.Entry<SslContextOption<?>, Object>... options) throws SSLException {
         if (enableOcsp) {
             throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
         }
+        Target_io_netty_handler_ssl_ResumptionController resumptionController = new Target_io_netty_handler_ssl_ResumptionController();
         return (SslContext) (Object) new Target_io_netty_handler_ssl_JdkSslClientContext(sslContextProvider,
                 trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                 keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                sessionTimeout, secureRandom, keyStoreType);
+                sessionTimeout, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
+                resumptionController);
     }
 
 }
@@ -382,31 +394,6 @@ final class Target_io_netty_bootstrap_AbstractBootstrap {
         return regFuture;
 
     }
-}
-
-@TargetClass(className = "io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop")
-final class Target_io_netty_channel_nio_NioEventLoop {
-
-    @Substitute
-    private static Queue<Runnable> newTaskQueue0(int maxPendingTasks) {
-        return new LinkedBlockingDeque<>();
-    }
-}
-
-@TargetClass(className = "io.grpc.netty.shaded.io.netty.buffer.AbstractReferenceCountedByteBuf")
-final class Target_io_netty_buffer_AbstractReferenceCountedByteBuf {
-
-    @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FieldOffset, name = "refCnt")
-    private static long REFCNT_FIELD_OFFSET;
-}
-
-@TargetClass(className = "io.grpc.netty.shaded.io.netty.util.AbstractReferenceCounted")
-final class Target_io_netty_util_AbstractReferenceCounted {
-
-    @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FieldOffset, name = "refCnt")
-    private static long REFCNT_FIELD_OFFSET;
 }
 
 // This class is runtime-initialized by NettyProcessor

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/graal/ZLibSubstitutions.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/graal/netty/runtime/graal/ZLibSubstitutions.java
@@ -61,6 +61,11 @@ final class Target_io_netty_handler_codec_compression_ZlibCodecFactory {
     }
 
     @Substitute
+    public static ZlibDecoder newZlibDecoder(ZlibWrapper wrapper, int maxAllocation) {
+        return new JdkZlibDecoder(wrapper, maxAllocation);
+    }
+
+    @Substitute
     public static ZlibDecoder newZlibDecoder(byte[] dictionary) {
         return new JdkZlibDecoder(dictionary);
     }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,8 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.27.2</quarkus.version>
+        <quarkus.version>3.33.1</quarkus.version>
         <temporal.version>1.33.0</temporal.version>
-        <opentelemetry.version>1.32.0</opentelemetry.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/test-extension/deployment/pom.xml
+++ b/test-extension/deployment/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/update-netty-substitutions.sh
+++ b/update-netty-substitutions.sh
@@ -121,6 +121,7 @@ echo "$counter - Deleting code we don't want in NettyProcessor and GrpcCommonPro
 ((counter++))
 ./deleteMethod.sh "LogCleanupFilterBuildItem cleanupMacDNSInLog" "$DEST_NETTY_DEPLOYMENT/NettyProcessor.java"
 ./deleteMethod.sh "public void configureNativeExecutable" "$DEST_GRPC_DEPLOYMENT/GrpcCommonProcessor.java"
+./deleteMethod.sh "private static void reflectiveClasses" "$DEST_GRPC_DEPLOYMENT/GrpcCommonProcessor.java"
 rm ${DEST_GRPC_RUNTIME}/runtime/graal/GrpcSubstitutions.java
 rm ${DEST_GRPC_DEPLOYMENT}/GrpcDotNames.java
 
@@ -131,6 +132,7 @@ echo "$counter - Deleting missing import"
 perl -ni -e 'print unless /import io\.grpc\.netty\.shaded\.io\.netty\.resolver\.dns\.DnsServerAddressStreamProviders;/' "$DEST_NETTY_DEPLOYMENT/NettyProcessor.java"
 perl -ni -e 'print unless
     /import java\.util\.Collection;/
+    || /import java\.util\.Set;/
     || /import io\.grpc\.internal\.DnsNameResolverProvider;/
     || /import io\.grpc\.internal\.PickFirstLoadBalancerProvider;/
     || /import io\.grpc\.netty\.shaded\.io\.grpc\.netty\.NettyChannelProvider;/
@@ -138,6 +140,7 @@ perl -ni -e 'print unless
     || /import io\.quarkus\.deployment\.builditem\.CombinedIndexBuildItem;/
     || /import io\.quarkus\.deployment\.builditem\.nativeimage\.ReflectiveClassBuildItem;/
     || /import org\.jboss\.jandex\.ClassInfo;/
+    || /import org\.jboss\.jandex\.DotName;/
     ' "$DEST_GRPC_DEPLOYMENT/GrpcCommonProcessor.java"
 
 # Step 9: Cleanup


### PR DESCRIPTION
- Updated quarkus.version property to 3.33.1
- Regenerated netty/gRPC substitutions via `update-netty-substitutions.sh`
- Fixed script to also delete dead `reflectiveClasses` helper method in `GrpcCommonProcessor`
- Renamed `quarkus-junit5` artifacts to `quarkus-junit` per [migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.33) (found in sub version 3.31 migration guide)
- Remove unused opentelemetry.version property