### PR TITLE
Fix/mock testworkflowenvironment per test

### DIFF
--- a/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
+++ b/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
@@ -755,7 +755,6 @@ package io.quarkiverse.temporal.it;
 
 import static io.quarkiverse.temporal.Constants.DEFAULT_WORKER_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 
 import jakarta.inject.Inject;
 
@@ -779,9 +778,6 @@ public class TestWorkflowEnvironmentFreshnessIT {
     TestWorkflowEnvironment testEnv;
 
     @Inject
-    WorkflowClient client;
-
-    @Inject
     FreshnessClientHolder applicationBean;
 
     @Test
@@ -800,9 +796,10 @@ public class TestWorkflowEnvironmentFreshnessIT {
     }
 
     private void runAndClose(String input) {
-        // Proves application code (not just the test class) sees the current test's client.
-        assertSame(testEnv.getWorkflowClient(), applicationBean.get());
-
+        // Uses the client injected into an application-code-style CDI bean (not the test
+        // class's own field) to prove the fix isn't limited to the test class's fields.
+        // If this client were stale, newWorkflowStub/ping below would fail or hang against
+        // a different (or already-closed) in-memory environment.
         WorkflowClient current = applicationBean.get();
         FreshnessWorkflow workflow = current.newWorkflowStub(FreshnessWorkflow.class,
                 WorkflowOptions.newBuilder().setTaskQueue(DEFAULT_WORKER_NAME).build());
@@ -815,6 +812,8 @@ public class TestWorkflowEnvironmentFreshnessIT {
     }
 }
 ```
+
+**Discovered while implementing this task:** the original `assertSame(testEnv.getWorkflowClient(), applicationBean.get())` was a broken assertion, not a real check - `applicationBean.get()` returns a CDI client proxy (a stable, synthetic wrapper object), while `testEnv.getWorkflowClient()` returns the real underlying SDK object directly; the two are never reference-equal by design, regardless of whether the fix works. Removed it - the workflow call succeeding through `applicationBean.get()` is itself the meaningful proof (a stale client would be wired to a different, or already-closed, in-memory environment and the call would fail or hang).
 
 - [ ] **Step 4: Run the integration test suite**
 

--- a/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
+++ b/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
@@ -1,0 +1,835 @@
+# Per-Test-Fresh Mock TestWorkflowEnvironment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `quarkus-temporal-test`'s injected `TestWorkflowEnvironment`/`WorkflowClient`/`WorkerFactory` fresh for every `@Test` method instead of one shared, leaking, `Singleton`-scoped instance for the whole test JVM run — fixing the bug demonstrated in [PR #233](https://github.com/quarkiverse/quarkus-temporal/pull/233) — without requiring any change to user test code.
+
+**Architecture:** `TestWorkflowEnvironment` becomes `ApplicationScoped` and `WorkflowClient` stays `ApplicationScoped` (already was); both get swapped per test via `QuarkusMock.installMockForType(...)` in a new `QuarkusTestBeforeEachCallback`. `WorkerFactory` is a `final` SDK class with only a `private` constructor and can't be CDI-proxied, so it becomes `@Dependent`-scoped instead, reading "whatever is currently prepared" from a plain static holder; a "prepare-ahead" `QuarkusTestAfterEachCallback` builds test N+1's environment during test N's teardown so it's already in the holder by the time test N+1 is constructed (CDI resolves `@Dependent` fields at construction time, before any callback can run). Worker/workflow-type registration (normally a one-time boot step) is captured as replayable closures and re-run against every fresh environment.
+
+**Tech Stack:** Quarkus 3.33.1 (Java, Maven multi-module), Temporal Java SDK (`temporal-sdk`, `temporal-testing`), JUnit 5, `quarkus-junit5` test-lifecycle callback SPI, Mockito (test-only, for the fixture regression coverage).
+
+**Spec:** `docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md`
+
+## Global Constraints
+
+- No changes to production (non-mock) code paths in `extension`. All new/changed behavior is gated behind `quarkus.temporal.enable-mock=true` (build-time) or is otherwise inert unless the `quarkus-temporal-test` extension is present.
+- No bytecode transforms (`BytecodeTransformerBuildItem`) anywhere in this design — that approach was tried and rejected (see spec, "Constraints discovered during investigation" #5, and "Approaches considered").
+- Every new dependency version comes from the existing `quarkus-bom` import (no explicit `<version>` needed for `quarkus-junit5` or `mockito-core`).
+- Regression/behavioral tests for the actual per-test-freshness fix MUST live in `integration-tests` (real `@QuarkusTest`, goes through the full `QuarkusTestExtension` lifecycle). `test-extension/deployment`'s `QuarkusUnitTest`-based tests do **not** invoke the `QuarkusTestBeforeEachCallback`/`QuarkusTestAfterEachCallback` SPI this fix relies on (verified by reading `QuarkusUnitTest`'s source) — a test written there would prove nothing about this fix.
+- Follow existing code style: 4-space indent, no javadoc beyond what's shown below, package-private where the existing code is package-private.
+
+---
+
+### Task 1: Capture worker registration for replay (`extension/runtime`)
+
+**Files:**
+- Create: `extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerRegistrationRegistry.java`
+- Modify: `extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerFactoryRecorder.java:196-214`
+
+**Interfaces:**
+- Produces: `WorkerRegistrationRegistry.record(Runnable)` and `WorkerRegistrationRegistry.replayAll()` — a static registry other modules (Task 6's callback) call into to re-run worker/workflow-type registration against a freshly created `WorkerFactory`.
+- Consumes: nothing new; `WorkerFactoryRecorder`'s existing fields (`runtimeConfig`, `buildtimeConfig`) and existing private methods (`createWorkerOptions`, `createQueueName`) are unchanged.
+
+This task has no externally-observable behavior change yet (worker creation logic is identical, just also recorded for later replay) — it's verified by confirming the existing test suite still passes.
+
+- [ ] **Step 1: Create the registry**
+
+```java
+package io.quarkiverse.temporal;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Captures worker/workflow-type registrations performed at boot so they can be replayed
+ * against a freshly created {@link io.temporal.worker.WorkerFactory} in test/mock mode.
+ *
+ * Populated unconditionally by {@link WorkerFactoryRecorder#createWorker}; only ever read
+ * by the {@code quarkus-temporal-test} extension.
+ */
+public final class WorkerRegistrationRegistry {
+
+    private static final List<Runnable> REGISTRATIONS = new CopyOnWriteArrayList<>();
+
+    private WorkerRegistrationRegistry() {
+    }
+
+    public static void record(Runnable registration) {
+        REGISTRATIONS.add(registration);
+    }
+
+    public static void replayAll() {
+        for (Runnable registration : REGISTRATIONS) {
+            registration.run();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Extract `createWorker`'s body into `doCreateWorker`, and record a replay closure**
+
+In `WorkerFactoryRecorder.java`, replace the existing `createWorker` method (lines 196-214):
+
+```java
+    public void createWorker(String name, List<Class<?>> workflows,
+            List<Class<?>> activities) {
+        // Workers are created during runtime init and registered with workflow/activity implementations.
+        // Starting polling threads is intentionally deferred to startWorkerFactory(...).
+        WorkerFactory workerFactory = CDI.current().select(WorkerFactory.class).get();
+        WorkerRuntimeConfig workerRuntimeConfig = runtimeConfig.getValue().worker().get(name);
+        WorkerBuildtimeConfig workerBuildtimeConfig = buildtimeConfig.worker().get(name);
+
+        Worker worker = workerFactory.newWorker(createQueueName(name, workerRuntimeConfig),
+                createWorkerOptions(workerRuntimeConfig, workerBuildtimeConfig));
+        for (var workflow : workflows) {
+            worker.registerWorkflowImplementationTypes(workflow);
+        }
+        if (buildtimeConfig.startWorkers()) {
+            for (var activity : activities) {
+                worker.registerActivitiesImplementations(CDI.current().select(activity).get());
+            }
+        }
+    }
+```
+
+with:
+
+```java
+    public void createWorker(String name, List<Class<?>> workflows,
+            List<Class<?>> activities) {
+        WorkerRegistrationRegistry.record(() -> doCreateWorker(name, workflows, activities));
+        doCreateWorker(name, workflows, activities);
+    }
+
+    private void doCreateWorker(String name, List<Class<?>> workflows,
+            List<Class<?>> activities) {
+        // Workers are created during runtime init (or replayed per test in mock mode) and
+        // registered with workflow/activity implementations.
+        // Starting polling threads is intentionally deferred to startWorkerFactory(...).
+        WorkerFactory workerFactory = CDI.current().select(WorkerFactory.class).get();
+        WorkerRuntimeConfig workerRuntimeConfig = runtimeConfig.getValue().worker().get(name);
+        WorkerBuildtimeConfig workerBuildtimeConfig = buildtimeConfig.worker().get(name);
+
+        Worker worker = workerFactory.newWorker(createQueueName(name, workerRuntimeConfig),
+                createWorkerOptions(workerRuntimeConfig, workerBuildtimeConfig));
+        for (var workflow : workflows) {
+            worker.registerWorkflowImplementationTypes(workflow);
+        }
+        if (buildtimeConfig.startWorkers()) {
+            for (var activity : activities) {
+                worker.registerActivitiesImplementations(CDI.current().select(activity).get());
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Build and run the existing extension test suite to confirm no regression**
+
+Run: `mvn -q -pl extension/runtime,extension/deployment -am test`
+Expected: BUILD SUCCESS, all existing tests pass (no behavior change yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerRegistrationRegistry.java extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerFactoryRecorder.java
+git commit -m "feat: capture worker registration for replay in mock/test mode"
+```
+
+---
+
+### Task 2: Add a CDI-current variant of `WorkflowClientOptionsSupport` (`extension/runtime`)
+
+**Files:**
+- Modify: `extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowClientOptionsSupport.java`
+
+**Interfaces:**
+- Produces: `WorkflowClientOptionsSupport.buildFromCurrentCdi(String namespace, Optional<String> identity)` — same result as `buildFromContext`, but resolvable outside of synthetic-bean creation (needed by Task 5's JUnit callback, which isn't inside a `SyntheticCreationalContext`).
+- Consumes: nothing new.
+
+- [ ] **Step 1: Refactor to share logic between `buildFromContext` and a new `buildFromCurrentCdi`**
+
+Replace the full contents of `WorkflowClientOptionsSupport.java` with:
+
+```java
+package io.quarkiverse.temporal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.util.TypeLiteral;
+
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.common.context.ContextPropagator;
+import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.WorkflowClientInterceptor;
+
+public final class WorkflowClientOptionsSupport {
+
+    private WorkflowClientOptionsSupport() {
+    }
+
+    public static WorkflowClientOptions buildFromContext(
+            SyntheticCreationalContext<?> context,
+            String namespace,
+            Optional<String> identity) {
+
+        Instance<DataConverter> dataConverterInstance = context.getInjectedReference(new TypeLiteral<>() {
+        }, Any.Literal.INSTANCE);
+        Instance<WorkflowClientInterceptor> interceptorInstance = context.getInjectedReference(new TypeLiteral<>() {
+        }, Any.Literal.INSTANCE);
+        Instance<ContextPropagator> contextPropagatorInstance = context.getInjectedReference(new TypeLiteral<>() {
+        }, Any.Literal.INSTANCE);
+
+        return build(namespace, identity, dataConverterInstance, interceptorInstance, contextPropagatorInstance);
+    }
+
+    /**
+     * Same result as {@link #buildFromContext}, but resolvable outside of synthetic bean
+     * creation (e.g. from a JUnit test-lifecycle callback), using {@link CDI#current()} directly.
+     */
+    public static WorkflowClientOptions buildFromCurrentCdi(String namespace, Optional<String> identity) {
+        Instance<DataConverter> dataConverterInstance = CDI.current().select(DataConverter.class, Any.Literal.INSTANCE);
+        Instance<WorkflowClientInterceptor> interceptorInstance = CDI.current().select(WorkflowClientInterceptor.class,
+                Any.Literal.INSTANCE);
+        Instance<ContextPropagator> contextPropagatorInstance = CDI.current().select(ContextPropagator.class,
+                Any.Literal.INSTANCE);
+
+        return build(namespace, identity, dataConverterInstance, interceptorInstance, contextPropagatorInstance);
+    }
+
+    private static WorkflowClientOptions build(
+            String namespace,
+            Optional<String> identity,
+            Instance<DataConverter> dataConverterInstance,
+            Instance<WorkflowClientInterceptor> interceptorInstance,
+            Instance<ContextPropagator> contextPropagatorInstance) {
+
+        WorkflowClientOptions.Builder builder = WorkflowClientOptions.newBuilder()
+                .setNamespace(namespace);
+
+        identity.ifPresent(builder::setIdentity);
+
+        DataConverter dataConverter = dataConverterInstance.isResolvable()
+                ? dataConverterInstance.get()
+                : null;
+
+        if (dataConverter != null) {
+            builder.setDataConverter(dataConverter);
+        }
+
+        List<WorkflowClientInterceptor> interceptors = interceptorInstance.stream()
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        if (!interceptors.isEmpty()) {
+            builder.setInterceptors(interceptors.toArray(new WorkflowClientInterceptor[0]));
+        }
+
+        List<ContextPropagator> propagators = contextPropagatorInstance.stream()
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (!propagators.isEmpty()) {
+            builder.setContextPropagators(propagators);
+        }
+
+        return builder.validateAndBuildWithDefaults();
+    }
+}
+```
+
+- [ ] **Step 2: Build and run the existing extension + test-extension suite to confirm no regression**
+
+Run: `mvn -q -pl extension/runtime,extension/deployment,test-extension/runtime,test-extension/deployment -am test`
+Expected: BUILD SUCCESS, all existing tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowClientOptionsSupport.java
+git commit -m "refactor: extract CDI.current()-based variant of WorkflowClientOptionsSupport"
+```
+
+---
+
+### Task 3: Add the prepare-ahead holder (`test-extension/runtime`)
+
+**Files:**
+- Create: `test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestEnvironmentHolder.java`
+- Modify: `test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java`
+
+**Interfaces:**
+- Produces: `MockTestEnvironmentHolder.current()` (returns `TestWorkflowEnvironment`, may be `null` before boot seeding) and `MockTestEnvironmentHolder.set(TestWorkflowEnvironment)` — consumed by Task 4's `WorkerFactory` synthetic bean producer and Task 5's callback.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Create the holder**
+
+```java
+package io.quarkiverse.temporal.test;
+
+import io.temporal.testing.TestWorkflowEnvironment;
+
+/**
+ * Holds the {@link TestWorkflowEnvironment} currently prepared for the in-progress (or
+ * about-to-start) test. Deliberately a plain static holder, not a CDI bean, so the
+ * {@code @Dependent}-scoped {@code WorkerFactory} synthetic bean can read it at CDI
+ * injection time - which happens at test-instance construction, before any JUnit
+ * lifecycle callback has a chance to run.
+ */
+public final class MockTestEnvironmentHolder {
+
+    private static volatile TestWorkflowEnvironment current;
+
+    private MockTestEnvironmentHolder() {
+    }
+
+    public static TestWorkflowEnvironment current() {
+        return current;
+    }
+
+    public static void set(TestWorkflowEnvironment environment) {
+        current = environment;
+    }
+}
+```
+
+- [ ] **Step 2: Wire `TestWorkflowRecorder` to seed and read the holder**
+
+Replace the full contents of `TestWorkflowRecorder.java` with:
+
+```java
+package io.quarkiverse.temporal.test;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.quarkiverse.temporal.WorkflowClientOptionsSupport;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.annotations.Recorder;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.testing.TestEnvironmentOptions;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.WorkerFactory;
+
+@Recorder
+public class TestWorkflowRecorder {
+    public Function<SyntheticCreationalContext<TestWorkflowEnvironment>, TestWorkflowEnvironment> createTestWorkflowEnvironment() {
+        return context -> {
+            TestEnvironmentOptions options = TestEnvironmentOptions.newBuilder()
+                    .setWorkflowClientOptions(createTestWorkflowClientOptions(context))
+                    .build();
+
+            TestWorkflowEnvironment environment = TestWorkflowEnvironment.newInstance(options);
+            // Seed the holder immediately: the @Dependent WorkerFactory bean (and the
+            // first test's MockTestWorkflowResetCallback) both read from it.
+            MockTestEnvironmentHolder.set(environment);
+            return environment;
+        };
+    }
+
+    /**
+     * Builds the {@link WorkflowClientOptions} used by the mock TestWorkflowEnvironment, while honoring the CDI wiring.
+     */
+    public WorkflowClientOptions createTestWorkflowClientOptions(SyntheticCreationalContext<?> context) {
+        return WorkflowClientOptionsSupport.buildFromContext(
+                context,
+                "default",
+                Optional.empty());
+    }
+
+    public Function<SyntheticCreationalContext<WorkflowClient>, WorkflowClient> createTestWorkflowClient() {
+        return context -> {
+            TestWorkflowEnvironment testWorkflowEnvironment = context.getInjectedReference(TestWorkflowEnvironment.class);
+            return testWorkflowEnvironment.getWorkflowClient();
+        };
+    }
+
+    public Function<SyntheticCreationalContext<WorkerFactory>, WorkerFactory> createTestWorkerFactory() {
+        return context -> MockTestEnvironmentHolder.current().getWorkerFactory();
+    }
+}
+```
+
+- [ ] **Step 3: Compile to confirm no errors (behavior not yet exercised until Task 4 changes the bean scopes)**
+
+Run: `mvn -q -pl test-extension/runtime -am compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestEnvironmentHolder.java test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java
+git commit -m "feat: add prepare-ahead holder for the mock TestWorkflowEnvironment"
+```
+
+---
+
+### Task 4: Change synthetic bean scopes (`test-extension/deployment`)
+
+**Files:**
+- Modify: `test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java`
+
+**Interfaces:**
+- Consumes: `TestWorkflowRecorder.createTestWorkflowEnvironment()`, `.createTestWorkflowClient()`, `.createTestWorkerFactory()` (Task 3, unchanged signatures).
+- Produces: the `TestWorkflowEnvironment`, `WorkflowClient`, `WorkerFactory` synthetic beans that Task 5's callback and Task 6's IT tests inject.
+
+- [ ] **Step 1: Change `TestWorkflowEnvironment`'s scope to `ApplicationScoped` and `WorkerFactory`'s scope to `Dependent`**
+
+Replace the full contents of `TemporalTestProcessor.java` with:
+
+```java
+package io.quarkiverse.temporal.test.deployment;
+
+import static io.quarkiverse.temporal.Constants.TEMPORAL_TESTING_CAPABILITY;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.ParameterizedType;
+
+import io.quarkiverse.temporal.deployment.TemporalProcessor;
+import io.quarkiverse.temporal.test.TestWorkflowRecorder;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.temporal.client.WorkflowClient;
+import io.temporal.common.context.ContextPropagator;
+import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.WorkflowClientInterceptor;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.WorkerFactory;
+
+public class TemporalTestProcessor {
+
+    private static final String FEATURE = "temporal-test";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void capabilities(BuildProducer<CapabilityBuildItem> capabilityProducer) {
+        capabilityProducer.produce(new CapabilityBuildItem(TEMPORAL_TESTING_CAPABILITY, "temporal"));
+    }
+
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep(onlyIf = TemporalProcessor.EnableMock.class)
+    SyntheticBeanBuildItem recordTestEnvironment(TestWorkflowRecorder recorder) {
+        return SyntheticBeanBuildItem
+                .configure(TestWorkflowEnvironment.class)
+                .scope(ApplicationScoped.class)
+                .unremovable()
+                .addInjectionPoint(
+                        ParameterizedType.create(Instance.class, ClassType.create(WorkflowClientInterceptor.class)),
+                        AnnotationInstance.builder(Any.class).build())
+                .addInjectionPoint(
+                        ParameterizedType.create(Instance.class, ClassType.create(ContextPropagator.class)),
+                        AnnotationInstance.builder(Any.class).build())
+                .addInjectionPoint(
+                        ParameterizedType.create(Instance.class, ClassType.create(DataConverter.class)),
+                        AnnotationInstance.builder(Any.class).build())
+                .createWith(recorder.createTestWorkflowEnvironment())
+                .setRuntimeInit()
+                .done();
+    }
+
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep(onlyIf = TemporalProcessor.EnableMock.class)
+    SyntheticBeanBuildItem recordWorkflowClient(TestWorkflowRecorder recorder) {
+
+        return SyntheticBeanBuildItem
+                .configure(WorkflowClient.class)
+                .scope(ApplicationScoped.class)
+                .unremovable()
+                .defaultBean()
+                .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
+                .createWith(recorder.createTestWorkflowClient())
+                .setRuntimeInit()
+                .done();
+    }
+
+    @BuildStep(onlyIf = TemporalProcessor.EnableMock.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    SyntheticBeanBuildItem produceWorkerFactorySyntheticBean(TestWorkflowRecorder recorder) {
+        // @Dependent (not a normal scope): io.temporal.worker.WorkerFactory is a final class
+        // with only a private constructor and cannot be CDI-proxied. A fresh instance is
+        // instead resolved from MockTestEnvironmentHolder at every injection point - see
+        // MockTestEnvironmentHolder / MockTestWorkflowResetCallback for how freshness is
+        // still achieved per test.
+        return SyntheticBeanBuildItem
+                .configure(WorkerFactory.class)
+                .scope(Dependent.class)
+                .unremovable()
+                .defaultBean()
+                .createWith(recorder.createTestWorkerFactory())
+                .setRuntimeInit()
+                .done();
+    }
+}
+```
+
+Note what changed from the original: `Singleton` import removed (no longer used), `Dependent` import added; `recordTestEnvironment`'s scope is now `ApplicationScoped`; `produceWorkerFactorySyntheticBean`'s scope is now `Dependent` and its now-unused `.addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))` is removed (the `createWith` function no longer reads it via `context.getInjectedReference(...)` — it reads `MockTestEnvironmentHolder` directly instead, per Task 3).
+
+- [ ] **Step 2: Build and run the existing test-extension suite to confirm no regression**
+
+Run: `mvn -q -pl test-extension/runtime,test-extension/deployment -am test`
+Expected: BUILD SUCCESS, all existing tests (`MockEnabledTest`, etc.) pass. (`StartWorkersEnabledTest`/`StartWorkersDisabledTest` are pre-existing `@Disabled` tests, unaffected either way — see Task 7.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
+git commit -m "fix: scope TestWorkflowEnvironment as ApplicationScoped, WorkerFactory as Dependent"
+```
+
+---
+
+### Task 5: The per-test reset callback (`test-extension/runtime`)
+
+**Files:**
+- Modify: `test-extension/runtime/pom.xml`
+- Create: `test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestWorkflowResetCallback.java`
+- Create: `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback`
+- Create: `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback`
+
+**Interfaces:**
+- Consumes: `MockTestEnvironmentHolder.current()`/`.set(...)` (Task 3), `WorkerRegistrationRegistry.replayAll()` (Task 1), `WorkflowClientOptionsSupport.buildFromCurrentCdi(...)` (Task 2).
+- Produces: nothing new consumed by later tasks — this is the last piece of the production fix. Tasks 6/7 exercise it end-to-end.
+
+- [ ] **Step 1: Add the `quarkus-junit5` dependency**
+
+In `test-extension/runtime/pom.xml`, add inside `<dependencies>` (alongside the existing `quarkus-arc`, `quarkus-temporal`, `temporal-sdk`, `temporal-testing` entries — no `<scope>` needed, this module is already test-classpath-only by design, same as its existing `temporal-testing` dependency):
+
+```xml
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+        </dependency>
+```
+
+- [ ] **Step 2: Write the callback**
+
+```java
+package io.quarkiverse.temporal.test;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.temporal.WorkerRegistrationRegistry;
+import io.quarkiverse.temporal.WorkflowClientOptionsSupport;
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+import io.temporal.client.WorkflowClient;
+import io.temporal.testing.TestEnvironmentOptions;
+import io.temporal.testing.TestWorkflowEnvironment;
+
+/**
+ * Gives every {@code @Test} method its own {@link TestWorkflowEnvironment} (and derived
+ * {@link WorkflowClient}/{@link io.temporal.worker.WorkerFactory}) instead of the single,
+ * shared, leaking instance the extension previously handed out for the whole test JVM run.
+ *
+ * <p>{@code TestWorkflowEnvironment} and {@code WorkflowClient} are swapped per test via
+ * {@link QuarkusMock}. {@code WorkerFactory} cannot use the same mechanism (it's a final SDK
+ * class with only a private constructor, so ArC can't generate a client proxy for it) - it is
+ * instead {@code @Dependent}-scoped and reads the "currently prepared" environment from
+ * {@link MockTestEnvironmentHolder}, which this callback prepares one test ahead: CDI resolves
+ * {@code @Dependent} fields at test-construction time, before {@link #beforeEach} can run, so
+ * the fresh instance has to already be in the holder by then.
+ */
+public class MockTestWorkflowResetCallback implements QuarkusTestBeforeEachCallback, QuarkusTestAfterEachCallback {
+
+    private static final Logger log = Logger.getLogger(MockTestWorkflowResetCallback.class);
+
+    private TestWorkflowEnvironment inUseForCurrentTest;
+
+    @Override
+    public void beforeEach(QuarkusTestMethodContext context) {
+        if (!isMockEnabled()) {
+            return;
+        }
+        // Already prepared - by app boot (the very first test) or by the previous test's
+        // afterEach (every test after that).
+        TestWorkflowEnvironment current = MockTestEnvironmentHolder.current();
+        if (current == null) {
+            return;
+        }
+        QuarkusMock.installMockForType(current, TestWorkflowEnvironment.class);
+        QuarkusMock.installMockForType(current.getWorkflowClient(), WorkflowClient.class);
+        this.inUseForCurrentTest = current;
+    }
+
+    @Override
+    public void afterEach(QuarkusTestMethodContext context) {
+        if (!isMockEnabled()) {
+            return;
+        }
+        TestWorkflowEnvironment justUsed = this.inUseForCurrentTest;
+        this.inUseForCurrentTest = null;
+        if (justUsed != null) {
+            shutdownQuietly(justUsed);
+        }
+        prepareNext();
+    }
+
+    private void prepareNext() {
+        TestEnvironmentOptions options = TestEnvironmentOptions.newBuilder()
+                .setWorkflowClientOptions(WorkflowClientOptionsSupport.buildFromCurrentCdi("default", Optional.empty()))
+                .build();
+        TestWorkflowEnvironment next = TestWorkflowEnvironment.newInstance(options);
+
+        MockTestEnvironmentHolder.set(next);
+        WorkerRegistrationRegistry.replayAll();
+
+        if (isStartWorkersEnabled()) {
+            next.getWorkerFactory().start();
+        }
+    }
+
+    private void shutdownQuietly(TestWorkflowEnvironment environment) {
+        try {
+            environment.getWorkerFactory().shutdown();
+        } catch (RuntimeException e) {
+            log.debugf(e, "Ignoring failure shutting down worker factory - likely already shut down by the test");
+        }
+        try {
+            environment.close();
+        } catch (RuntimeException e) {
+            log.debugf(e, "Ignoring failure closing test workflow environment - likely already closed by the test");
+        }
+    }
+
+    private static boolean isMockEnabled() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.temporal.enable-mock", Boolean.class)
+                .orElse(false);
+    }
+
+    private static boolean isStartWorkersEnabled() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.temporal.start-workers", Boolean.class)
+                .orElse(false);
+    }
+}
+```
+
+- [ ] **Step 3: Register the callback for auto-discovery**
+
+Create `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback` containing exactly:
+
+```
+io.quarkiverse.temporal.test.MockTestWorkflowResetCallback
+```
+
+Create `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback` containing exactly:
+
+```
+io.quarkiverse.temporal.test.MockTestWorkflowResetCallback
+```
+
+- [ ] **Step 4: Build and run the existing test-extension suite to confirm no regression**
+
+Run: `mvn -q -pl test-extension/runtime,test-extension/deployment -am test`
+Expected: BUILD SUCCESS. (Still no new *behavioral* proof yet - `test-extension/deployment`'s tests use `QuarkusUnitTest`, which doesn't invoke this callback at all. Task 6 is where this gets actually exercised.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test-extension/runtime/pom.xml test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestWorkflowResetCallback.java test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
+git commit -m "feat: reset the mock TestWorkflowEnvironment before/after every test method"
+```
+
+---
+
+### Task 6: Regression proof (`integration-tests`)
+
+**Files:**
+- Create: `integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/defaultWorker/FreshnessWorkflow.java`
+- Create: `integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/defaultWorker/FreshnessWorkflowImpl.java`
+- Create: `integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/FreshnessClientHolder.java`
+- Create: `integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowEnvironmentFreshnessIT.java`
+
+**Interfaces:**
+- Consumes: the fix from Tasks 1-5, exercised through ordinary `@Inject` — no direct code coupling, this task only proves behavior.
+
+This module already depends on `quarkus-temporal-test` (test scope) and already has real `@QuarkusTest`/`*IT` classes (`CDIActivityIT`, `MoneyTransferIT`) using the module's default `application.properties` (`%test.quarkus.temporal.enable-mock=true`, `start-workers` defaulting to `true`). The new fixture is placed under a `defaultWorker` sub-package, mirroring the existing `it.cdi.defaultWorker`/`it.moneyTransfer.defaultWorker` convention that binds a workflow implementation to the extension's default worker - no new worker/task-queue config needed, and `start-workers=true` means the workflow gets auto-registered per test with no manual mock-activity setup required (this fixture needs no activities at all).
+
+- [ ] **Step 1: Add the trivial fixture workflow**
+
+```java
+package io.quarkiverse.temporal.it.freshness.defaultWorker;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface FreshnessWorkflow {
+
+    @WorkflowMethod
+    String ping(String input);
+}
+```
+
+```java
+package io.quarkiverse.temporal.it.freshness.defaultWorker;
+
+public class FreshnessWorkflowImpl implements FreshnessWorkflow {
+
+    @Override
+    public String ping(String input) {
+        return "pong:" + input;
+    }
+}
+```
+
+- [ ] **Step 2: Add the application-code CDI bean that proves the fix isn't limited to the test class's own fields**
+
+```java
+package io.quarkiverse.temporal.it.freshness;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.temporal.client.WorkflowClient;
+
+/**
+ * Stands in for ordinary application code (a REST resource, a service) that injects
+ * {@link WorkflowClient} once and is never reconstructed per test - unlike the test class
+ * itself, which JUnit reconstructs for every test method.
+ */
+@ApplicationScoped
+public class FreshnessClientHolder {
+
+    @Inject
+    WorkflowClient workflowClient;
+
+    public WorkflowClient get() {
+        return workflowClient;
+    }
+}
+```
+
+- [ ] **Step 3: Write the regression test**
+
+```java
+package io.quarkiverse.temporal.it;
+
+import static io.quarkiverse.temporal.Constants.DEFAULT_WORKER_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkiverse.temporal.it.freshness.FreshnessClientHolder;
+import io.quarkiverse.temporal.it.freshness.defaultWorker.FreshnessWorkflow;
+import io.quarkus.test.junit.QuarkusTest;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowEnvironment;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestWorkflowEnvironmentFreshnessIT {
+
+    @Inject
+    TestWorkflowEnvironment testEnv;
+
+    @Inject
+    WorkflowClient client;
+
+    @Inject
+    FreshnessClientHolder applicationBean;
+
+    @Test
+    @Order(1)
+    public void firstTestRunsAndClosesTheEnvironment() {
+        runAndClose("first");
+    }
+
+    @Test
+    @Order(2)
+    public void secondTestGetsAFreshEnvironment() {
+        // Before the fix, this method received the same, already-closed
+        // TestWorkflowEnvironment as the first test, and testEnv.getWorkerFactory()
+        // below would already be shut down.
+        runAndClose("second");
+    }
+
+    private void runAndClose(String input) {
+        // Proves application code (not just the test class) sees the current test's client.
+        assertSame(testEnv.getWorkflowClient(), applicationBean.get());
+
+        WorkflowClient current = applicationBean.get();
+        FreshnessWorkflow workflow = current.newWorkflowStub(FreshnessWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(DEFAULT_WORKER_NAME).build());
+        try {
+            assertEquals("pong:" + input, workflow.ping(input));
+        } finally {
+            testEnv.getWorkerFactory().shutdown();
+            testEnv.close();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the integration test suite**
+
+Run: `mvn -q verify -pl integration-tests -am`
+Expected: BUILD SUCCESS, both `testWorkflowEnvironmentFreshnessIT` methods pass. If this plan were executed against the *old* (pre-fix) code, `secondTestGetsAFreshEnvironment` would fail with an error indicating the worker factory/environment was already shut down - that's the regression this proves.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowEnvironmentFreshnessIT.java
+git commit -m "test: prove TestWorkflowEnvironment/WorkflowClient are fresh per test method"
+```
+
+---
+
+### Task 7: Full suite verification, and a quick look at the disabled tests
+
+**Files:**
+- Investigate only (no guaranteed changes): `test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersEnabledTest.java`, `StartWorkersDisabledTest.java`
+
+**Interfaces:** none - this task is verification, not new code.
+
+- [ ] **Step 1: Run the full reactor test suite**
+
+Run: `mvn -q verify`
+Expected: BUILD SUCCESS across `extension`, `test-extension`, and `integration-tests` - including the pre-existing `CDIActivityIT`, `MoneyTransferIT`, `ContextPropagatorCdiIT`, `DataConverterCdiIT` (none of which explicitly close their environment, so they must keep working unchanged under the new fresh-per-test behavior).
+
+- [ ] **Step 2: Look at why `StartWorkersEnabledTest`/`StartWorkersDisabledTest` are `@Disabled`**
+
+These two tests (in `test-extension/deployment`) are `QuarkusUnitTest`-based and were disabled in commit `700eeff` ("custom client") with no explanation. Read them, try removing `@Disabled` locally, and run:
+
+Run: `mvn -q -pl test-extension/deployment -am test -Dtest=StartWorkersEnabledTest,StartWorkersDisabledTest`
+
+If they pass cleanly after this change, remove the `@Disabled` annotations and commit that as a small separate cleanup. If they still fail for a reason unrelated to this fix, leave them disabled - this is a nice-to-have, not a requirement of this plan.
+
+- [ ] **Step 3: Final commit (only if Step 2 produced a change)**
+
+```bash
+git add test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersEnabledTest.java test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersDisabledTest.java
+git commit -m "test: re-enable StartWorkersEnabledTest/StartWorkersDisabledTest"
+```

--- a/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
+++ b/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
@@ -32,7 +32,7 @@
 
 This task has no externally-observable behavior change yet (worker creation logic is identical, just also recorded for later replay) — it's verified by confirming the existing test suite still passes.
 
-- [ ] **Step 1: Create the registry**
+- [x] **Step 1: Create the registry**
 
 ```java
 package io.quarkiverse.temporal;
@@ -66,7 +66,7 @@ public final class WorkerRegistrationRegistry {
 }
 ```
 
-- [ ] **Step 2: Extract `createWorker`'s body into `doCreateWorker`, and record a replay closure**
+- [x] **Step 2: Extract `createWorker`'s body into `doCreateWorker`, and record a replay closure**
 
 In `WorkerFactoryRecorder.java`, replace the existing `createWorker` method (lines 196-214):
 
@@ -123,12 +123,12 @@ with:
     }
 ```
 
-- [ ] **Step 3: Build and run the existing extension test suite to confirm no regression**
+- [x] **Step 3: Build and run the existing extension test suite to confirm no regression**
 
 Run: `mvn -q -pl extension/runtime,extension/deployment -am test`
 Expected: BUILD SUCCESS, all existing tests pass (no behavior change yet).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerRegistrationRegistry.java extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerFactoryRecorder.java
@@ -146,7 +146,7 @@ git commit -m "feat: capture worker registration for replay in mock/test mode"
 - Produces: `WorkflowClientOptionsSupport.buildFromCurrentCdi(String namespace, Optional<String> identity)` — same result as `buildFromContext`, but resolvable outside of synthetic-bean creation (needed by Task 5's JUnit callback, which isn't inside a `SyntheticCreationalContext`).
 - Consumes: nothing new.
 
-- [ ] **Step 1: Refactor to share logic between `buildFromContext` and a new `buildFromCurrentCdi`**
+- [x] **Step 1: Refactor to share logic between `buildFromContext` and a new `buildFromCurrentCdi`**
 
 Replace the full contents of `WorkflowClientOptionsSupport.java` with:
 
@@ -241,12 +241,12 @@ public final class WorkflowClientOptionsSupport {
 }
 ```
 
-- [ ] **Step 2: Build and run the existing extension + test-extension suite to confirm no regression**
+- [x] **Step 2: Build and run the existing extension + test-extension suite to confirm no regression**
 
 Run: `mvn -q -pl extension/runtime,extension/deployment,test-extension/runtime,test-extension/deployment -am test`
 Expected: BUILD SUCCESS, all existing tests pass.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowClientOptionsSupport.java
@@ -265,7 +265,7 @@ git commit -m "refactor: extract CDI.current()-based variant of WorkflowClientOp
 - Produces: `MockTestEnvironmentHolder.current()` (returns `TestWorkflowEnvironment`, may be `null` before boot seeding) and `MockTestEnvironmentHolder.set(TestWorkflowEnvironment)` — consumed by Task 4's `WorkerFactory` synthetic bean producer and Task 5's callback.
 - Consumes: nothing new.
 
-- [ ] **Step 1: Create the holder**
+- [x] **Step 1: Create the holder**
 
 ```java
 package io.quarkiverse.temporal.test;
@@ -296,7 +296,7 @@ public final class MockTestEnvironmentHolder {
 }
 ```
 
-- [ ] **Step 2: Wire `TestWorkflowRecorder` to seed and read the holder**
+- [x] **Step 2: Wire `TestWorkflowRecorder` to seed and read the holder**
 
 Replace the full contents of `TestWorkflowRecorder.java` with:
 
@@ -363,12 +363,12 @@ public class TestWorkflowRecorder {
 }
 ```
 
-- [ ] **Step 3: Compile to confirm no errors (behavior not yet exercised until Task 4 changes the bean scopes)**
+- [x] **Step 3: Compile to confirm no errors (behavior not yet exercised until Task 4 changes the bean scopes)**
 
 Run: `mvn -q -pl test-extension/runtime -am compile`
 Expected: BUILD SUCCESS.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestEnvironmentHolder.java test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java
@@ -386,7 +386,7 @@ git commit -m "feat: add prepare-ahead holder for the mock TestWorkflowEnvironme
 - Consumes: `TestWorkflowRecorder.createTestWorkflowEnvironment()`, `.createTestWorkflowClient()`, `.createTestWorkerFactory()` (Task 3, unchanged signatures).
 - Produces: the `TestWorkflowEnvironment`, `WorkflowClient`, `WorkerFactory` synthetic beans that Task 5's callback and Task 6's IT tests inject.
 
-- [ ] **Step 1: Change `TestWorkflowEnvironment`'s scope to `ApplicationScoped` and `WorkerFactory`'s scope to `Dependent`**
+- [x] **Step 1: Change `TestWorkflowEnvironment`'s scope to `ApplicationScoped` and `WorkerFactory`'s scope to `Dependent`**
 
 Replace the full contents of `TemporalTestProcessor.java` with:
 
@@ -499,12 +499,12 @@ Note what changed from the original: `Singleton` import removed (no longer used)
 
 **Discovered while implementing this task:** removing the `TestWorkflowEnvironment` injection point entirely broke boot - `WorkerFactoryRecorder.startWorkerFactory` resolves `WorkerFactory` before anything else forces `TestWorkflowEnvironment` to be created (e.g. in a test with no declared workers, nothing else ever touches it), so `MockTestEnvironmentHolder.current()` was `null`. Declaring the injection point isn't enough by itself either - `TestWorkflowEnvironment` is a normal-scoped (proxied) bean now, so merely obtaining the injected reference doesn't trigger creation, only invoking a method on it does (this is why `createTestWorkflowClient()` already worked unchanged - it calls `.getWorkflowClient()`). The fix, reflected in Task 3's final `createTestWorkerFactory()` above: keep the injection point, resolve it, and call `.getWorkerFactory()` on it (discarding the result) purely to force creation/holder-seeding, then read the actual return value from the holder.
 
-- [ ] **Step 2: Build and run the existing test-extension suite to confirm no regression**
+- [x] **Step 2: Build and run the existing test-extension suite to confirm no regression**
 
 Run: `mvn -q -pl test-extension/runtime,test-extension/deployment -am test`
 Expected: BUILD SUCCESS, all existing tests (`MockEnabledTest`, etc.) pass. (`StartWorkersEnabledTest`/`StartWorkersDisabledTest` are pre-existing `@Disabled` tests, unaffected either way — see Task 7.)
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
@@ -525,7 +525,7 @@ git commit -m "fix: scope TestWorkflowEnvironment as ApplicationScoped, WorkerFa
 - Consumes: `MockTestEnvironmentHolder.current()`/`.set(...)` (Task 3), `WorkerRegistrationRegistry.replayAll()` (Task 1), `WorkflowClientOptionsSupport.buildFromCurrentCdi(...)` (Task 2).
 - Produces: nothing new consumed by later tasks — this is the last piece of the production fix. Tasks 6/7 exercise it end-to-end.
 
-- [ ] **Step 1: Add the `quarkus-junit` dependency**
+- [x] **Step 1: Add the `quarkus-junit` dependency**
 
 In `test-extension/runtime/pom.xml`, add inside `<dependencies>`:
 
@@ -543,7 +543,7 @@ First, `quarkus-junit5` (the artifact one might expect from older Quarkus docs) 
 
 Second, `<scope>provided</scope>` is required, not optional: `quarkus-junit` (like `quarkus-junit5`) legitimately depends on `-deployment` artifacts (needed for `@QuarkusTest`'s own re-augmentation support), and the `quarkus-extension-maven-plugin`'s dependency verification step correctly rejects any `-deployment` artifact appearing on an extension runtime module's default (compile-scope) classpath - real consumers must never see build-time artifacts on their production classpath. `provided` scope makes the classes available for compiling this module without tripping that check. This doesn't leave consumers missing anything at runtime: anyone using `@QuarkusTest` (which is what's needed for this callback to ever run at all) already has `quarkus-junit` on their own test classpath directly, regardless of what `quarkus-temporal-test` declares.
 
-- [ ] **Step 2: Write the callback**
+- [x] **Step 2: Write the callback**
 
 ```java
 package io.quarkiverse.temporal.test;
@@ -652,7 +652,7 @@ public class MockTestWorkflowResetCallback implements QuarkusTestBeforeEachCallb
 }
 ```
 
-- [ ] **Step 3: Register the callback for auto-discovery**
+- [x] **Step 3: Register the callback for auto-discovery**
 
 Create `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback` containing exactly:
 
@@ -666,12 +666,12 @@ Create `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.t
 io.quarkiverse.temporal.test.MockTestWorkflowResetCallback
 ```
 
-- [ ] **Step 4: Build and run the existing test-extension suite to confirm no regression**
+- [x] **Step 4: Build and run the existing test-extension suite to confirm no regression**
 
 Run: `mvn -q -pl test-extension/runtime,test-extension/deployment -am test`
 Expected: BUILD SUCCESS. (Still no new *behavioral* proof yet - `test-extension/deployment`'s tests use `QuarkusUnitTest`, which doesn't invoke this callback at all. Task 6 is where this gets actually exercised.)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add test-extension/runtime/pom.xml test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestWorkflowResetCallback.java test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
@@ -693,7 +693,7 @@ git commit -m "feat: reset the mock TestWorkflowEnvironment before/after every t
 
 This module already depends on `quarkus-temporal-test` (test scope) and already has real `@QuarkusTest`/`*IT` classes (`CDIActivityIT`, `MoneyTransferIT`) using the module's default `application.properties` (`%test.quarkus.temporal.enable-mock=true`, `start-workers` defaulting to `true`). The new fixture is placed under a `defaultWorker` sub-package, mirroring the existing `it.cdi.defaultWorker`/`it.moneyTransfer.defaultWorker` convention that binds a workflow implementation to the extension's default worker - no new worker/task-queue config needed, and `start-workers=true` means the workflow gets auto-registered per test with no manual mock-activity setup required (this fixture needs no activities at all).
 
-- [ ] **Step 1: Add the trivial fixture workflow**
+- [x] **Step 1: Add the trivial fixture workflow**
 
 ```java
 package io.quarkiverse.temporal.it.freshness.defaultWorker;
@@ -721,7 +721,7 @@ public class FreshnessWorkflowImpl implements FreshnessWorkflow {
 }
 ```
 
-- [ ] **Step 2: Add the application-code CDI bean that proves the fix isn't limited to the test class's own fields**
+- [x] **Step 2: Add the application-code CDI bean that proves the fix isn't limited to the test class's own fields**
 
 ```java
 package io.quarkiverse.temporal.it.freshness;
@@ -748,7 +748,7 @@ public class FreshnessClientHolder {
 }
 ```
 
-- [ ] **Step 3: Write the regression test**
+- [x] **Step 3: Write the regression test**
 
 ```java
 package io.quarkiverse.temporal.it;
@@ -815,12 +815,12 @@ public class TestWorkflowEnvironmentFreshnessIT {
 
 **Discovered while implementing this task:** the original `assertSame(testEnv.getWorkflowClient(), applicationBean.get())` was a broken assertion, not a real check - `applicationBean.get()` returns a CDI client proxy (a stable, synthetic wrapper object), while `testEnv.getWorkflowClient()` returns the real underlying SDK object directly; the two are never reference-equal by design, regardless of whether the fix works. Removed it - the workflow call succeeding through `applicationBean.get()` is itself the meaningful proof (a stale client would be wired to a different, or already-closed, in-memory environment and the call would fail or hang).
 
-- [ ] **Step 4: Run the integration test suite**
+- [x] **Step 4: Run the integration test suite**
 
 Run: `mvn -q verify -pl integration-tests -am`
 Expected: BUILD SUCCESS, both `testWorkflowEnvironmentFreshnessIT` methods pass. If this plan were executed against the *old* (pre-fix) code, `secondTestGetsAFreshEnvironment` would fail with an error indicating the worker factory/environment was already shut down - that's the regression this proves.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowEnvironmentFreshnessIT.java
@@ -836,12 +836,12 @@ git commit -m "test: prove TestWorkflowEnvironment/WorkflowClient are fresh per 
 
 **Interfaces:** none - this task is verification, not new code.
 
-- [ ] **Step 1: Run the full reactor test suite**
+- [x] **Step 1: Run the full reactor test suite**
 
 Run: `mvn -q verify`
 Expected: BUILD SUCCESS across `extension`, `test-extension`, and `integration-tests` - including the pre-existing `CDIActivityIT`, `MoneyTransferIT`, `ContextPropagatorCdiIT`, `DataConverterCdiIT` (none of which explicitly close their environment, so they must keep working unchanged under the new fresh-per-test behavior).
 
-- [ ] **Step 2: Look at why `StartWorkersEnabledTest`/`StartWorkersDisabledTest` are `@Disabled`**
+- [x] **Step 2: Look at why `StartWorkersEnabledTest`/`StartWorkersDisabledTest` are `@Disabled`**
 
 These two tests (in `test-extension/deployment`) are `QuarkusUnitTest`-based and were disabled in commit `700eeff` ("custom client") with no explanation. Read them, try removing `@Disabled` locally, and run:
 
@@ -849,7 +849,7 @@ Run: `mvn -q -pl test-extension/deployment -am test -Dtest=StartWorkersEnabledTe
 
 If they pass cleanly after this change, remove the `@Disabled` annotations and commit that as a small separate cleanup. If they still fail for a reason unrelated to this fix, leave them disabled - this is a nice-to-have, not a requirement of this plan.
 
-- [ ] **Step 3: Final commit (only if Step 2 produced a change)**
+- [x] **Step 3: Final commit (only if Step 2 produced a change)**
 
 ```bash
 git add test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersEnabledTest.java test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersDisabledTest.java

--- a/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
+++ b/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
@@ -6,7 +6,7 @@
 
 **Architecture:** `TestWorkflowEnvironment` becomes `ApplicationScoped` and `WorkflowClient` stays `ApplicationScoped` (already was); both get swapped per test via `QuarkusMock.installMockForType(...)` in a new `QuarkusTestBeforeEachCallback`. `WorkerFactory` is a `final` SDK class with only a `private` constructor and can't be CDI-proxied, so it becomes `@Dependent`-scoped instead, reading "whatever is currently prepared" from a plain static holder; a "prepare-ahead" `QuarkusTestAfterEachCallback` builds test N+1's environment during test N's teardown so it's already in the holder by the time test N+1 is constructed (CDI resolves `@Dependent` fields at construction time, before any callback can run). Worker/workflow-type registration (normally a one-time boot step) is captured as replayable closures and re-run against every fresh environment.
 
-**Tech Stack:** Quarkus 3.33.1 (Java, Maven multi-module), Temporal Java SDK (`temporal-sdk`, `temporal-testing`), JUnit 5, `quarkus-junit5` test-lifecycle callback SPI, Mockito (test-only, for the fixture regression coverage).
+**Tech Stack:** Quarkus 3.33.1 (Java, Maven multi-module), Temporal Java SDK (`temporal-sdk`, `temporal-testing`), JUnit 5, `quarkus-junit`'s test-lifecycle callback SPI (`io.quarkus.test.junit.callback.*`), Mockito (test-only, for the fixture regression coverage).
 
 **Spec:** `docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md`
 
@@ -14,7 +14,7 @@
 
 - No changes to production (non-mock) code paths in `extension`. All new/changed behavior is gated behind `quarkus.temporal.enable-mock=true` (build-time) or is otherwise inert unless the `quarkus-temporal-test` extension is present.
 - No bytecode transforms (`BytecodeTransformerBuildItem`) anywhere in this design — that approach was tried and rejected (see spec, "Constraints discovered during investigation" #5, and "Approaches considered").
-- Every new dependency version comes from the existing `quarkus-bom` import (no explicit `<version>` needed for `quarkus-junit5` or `mockito-core`).
+- Every new dependency version comes from the existing `quarkus-bom` import (no explicit `<version>` needed for `quarkus-junit` or `mockito-core`).
 - Regression/behavioral tests for the actual per-test-freshness fix MUST live in `integration-tests` (real `@QuarkusTest`, goes through the full `QuarkusTestExtension` lifecycle). `test-extension/deployment`'s `QuarkusUnitTest`-based tests do **not** invoke the `QuarkusTestBeforeEachCallback`/`QuarkusTestAfterEachCallback` SPI this fix relies on (verified by reading `QuarkusUnitTest`'s source) — a test written there would prove nothing about this fix.
 - Follow existing code style: 4-space indent, no javadoc beyond what's shown below, package-private where the existing code is package-private.
 
@@ -525,16 +525,23 @@ git commit -m "fix: scope TestWorkflowEnvironment as ApplicationScoped, WorkerFa
 - Consumes: `MockTestEnvironmentHolder.current()`/`.set(...)` (Task 3), `WorkerRegistrationRegistry.replayAll()` (Task 1), `WorkflowClientOptionsSupport.buildFromCurrentCdi(...)` (Task 2).
 - Produces: nothing new consumed by later tasks — this is the last piece of the production fix. Tasks 6/7 exercise it end-to-end.
 
-- [ ] **Step 1: Add the `quarkus-junit5` dependency**
+- [ ] **Step 1: Add the `quarkus-junit` dependency**
 
-In `test-extension/runtime/pom.xml`, add inside `<dependencies>` (alongside the existing `quarkus-arc`, `quarkus-temporal`, `temporal-sdk`, `temporal-testing` entries — no `<scope>` needed, this module is already test-classpath-only by design, same as its existing `temporal-testing` dependency):
+In `test-extension/runtime/pom.xml`, add inside `<dependencies>`:
 
 ```xml
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>provided</scope>
         </dependency>
 ```
+
+**Discovered while implementing this task:** two corrections from what's written above.
+
+First, `quarkus-junit5` (the artifact one might expect from older Quarkus docs) is not what provides `QuarkusMock`/the callback SPI in this Quarkus version (3.33.1) - `quarkus-junit` is, and it's also the artifact `integration-tests` already uses for its own `@QuarkusTest` classes, so this keeps the whole repo on one convention.
+
+Second, `<scope>provided</scope>` is required, not optional: `quarkus-junit` (like `quarkus-junit5`) legitimately depends on `-deployment` artifacts (needed for `@QuarkusTest`'s own re-augmentation support), and the `quarkus-extension-maven-plugin`'s dependency verification step correctly rejects any `-deployment` artifact appearing on an extension runtime module's default (compile-scope) classpath - real consumers must never see build-time artifacts on their production classpath. `provided` scope makes the classes available for compiling this module without tripping that check. This doesn't leave consumers missing anything at runtime: anyone using `@QuarkusTest` (which is what's needed for this callback to ever run at all) already has `quarkus-junit` on their own test classpath directly, regardless of what `quarkus-temporal-test` declares.
 
 - [ ] **Step 2: Write the callback**
 

--- a/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
+++ b/docs/superpowers/plans/2026-08-30-per-test-mock-environment.md
@@ -349,7 +349,16 @@ public class TestWorkflowRecorder {
     }
 
     public Function<SyntheticCreationalContext<WorkerFactory>, WorkerFactory> createTestWorkerFactory() {
-        return context -> MockTestEnvironmentHolder.current().getWorkerFactory();
+        return context -> {
+            // TestWorkflowEnvironment is ApplicationScoped (proxied): merely obtaining the
+            // injected reference does not trigger its creation, only invoking a method on it
+            // does. That first creation is what seeds MockTestEnvironmentHolder, which is
+            // then read below (not the value returned here) so later tests - which swap the
+            // holder directly - are picked up too.
+            TestWorkflowEnvironment testWorkflowEnvironment = context.getInjectedReference(TestWorkflowEnvironment.class);
+            testWorkflowEnvironment.getWorkerFactory();
+            return MockTestEnvironmentHolder.current().getWorkerFactory();
+        };
     }
 }
 ```
@@ -469,11 +478,16 @@ public class TemporalTestProcessor {
         // instead resolved from MockTestEnvironmentHolder at every injection point - see
         // MockTestEnvironmentHolder / MockTestWorkflowResetCallback for how freshness is
         // still achieved per test.
+        // The TestWorkflowEnvironment injection point below is not read directly by
+        // createTestWorkerFactory() any more, but it must stay: declaring (and resolving) it
+        // is what forces ArC to create the TestWorkflowEnvironment bean - and so seed the
+        // holder - before this bean is ever created.
         return SyntheticBeanBuildItem
                 .configure(WorkerFactory.class)
                 .scope(Dependent.class)
                 .unremovable()
                 .defaultBean()
+                .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
                 .createWith(recorder.createTestWorkerFactory())
                 .setRuntimeInit()
                 .done();
@@ -481,7 +495,9 @@ public class TemporalTestProcessor {
 }
 ```
 
-Note what changed from the original: `Singleton` import removed (no longer used), `Dependent` import added; `recordTestEnvironment`'s scope is now `ApplicationScoped`; `produceWorkerFactorySyntheticBean`'s scope is now `Dependent` and its now-unused `.addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))` is removed (the `createWith` function no longer reads it via `context.getInjectedReference(...)` — it reads `MockTestEnvironmentHolder` directly instead, per Task 3).
+Note what changed from the original: `Singleton` import removed (no longer used), `Dependent` import added; `recordTestEnvironment`'s scope is now `ApplicationScoped`; `produceWorkerFactorySyntheticBean`'s scope is now `Dependent` (its `WorkflowClient` injection point, unused for the same reason, is removed - but its `TestWorkflowEnvironment` injection point must stay, see below).
+
+**Discovered while implementing this task:** removing the `TestWorkflowEnvironment` injection point entirely broke boot - `WorkerFactoryRecorder.startWorkerFactory` resolves `WorkerFactory` before anything else forces `TestWorkflowEnvironment` to be created (e.g. in a test with no declared workers, nothing else ever touches it), so `MockTestEnvironmentHolder.current()` was `null`. Declaring the injection point isn't enough by itself either - `TestWorkflowEnvironment` is a normal-scoped (proxied) bean now, so merely obtaining the injected reference doesn't trigger creation, only invoking a method on it does (this is why `createTestWorkflowClient()` already worked unchanged - it calls `.getWorkflowClient()`). The fix, reflected in Task 3's final `createTestWorkerFactory()` above: keep the injection point, resolve it, and call `.getWorkerFactory()` on it (discarding the result) purely to force creation/holder-seeding, then read the actual return value from the holder.
 
 - [ ] **Step 2: Build and run the existing test-extension suite to confirm no regression**
 

--- a/docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md
+++ b/docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md
@@ -11,17 +11,19 @@ Goal: make the extension-provided `TestWorkflowEnvironment`/`WorkflowClient`/`Wo
 ## Constraints discovered during investigation
 
 1. **Worker/workflow-type registration is also a one-time boot step.** `TemporalProcessor.setupWorkerFactory` (a `@Record(RUNTIME_INIT)` build step) calls `WorkerFactoryRecorder.createWorker(name, workflows, activities)` once per declared worker, against whatever `WorkerFactory` bean exists at that moment. A naive "swap the environment" fix would leave every subsequent test's fresh `WorkerFactory` with zero registered workers/workflow types.
-2. **`io.temporal.worker.WorkerFactory` is a `final` class.** CDI/ArC cannot generate a normal-scope client proxy for a final class (subclassing is required and impossible). `TestWorkflowEnvironment` and `WorkflowClient` are interfaces and are proxyable.
-3. **CDI field injection into a `@QuarkusTest` instance happens at test-instance construction time** (`QuarkusTestExtension.interceptTestClassConstructor`), which runs *before* any `QuarkusTestBeforeEachCallback`/`QuarkusTestAfterConstructCallback` fires. A plain re-assignment of a bean's backing value in a `BeforeEachCallback` would be too late to affect an already-injected raw field reference — unless the injected reference is a *proxy* whose delegate can be swapped after the fact.
-4. Quarkus already solves both (2) and (3) elsewhere: `io.quarkus.test.junit.QuarkusMock` (`installMockForType`/`installMockForInstance`) swaps what a **normal-scoped** bean's client proxy delegates to, for the duration of one test, and this is exactly how `@InjectMock`/Mockito support works internally (`SetMockitoMockAsBeanMockCallback`, a `QuarkusTestBeforeEachCallback`, uses it). `QuarkusTestExtension.beforeEach()` calls `pushMockContext()` *before* invoking `QuarkusTestBeforeEachCallback`s, and `afterEach()` calls `popMockContext()` after ours — so mock installs made inside our callback are automatically test-scoped with no manual cleanup needed.
-5. Quarkus's standard technique for proxying a third-party `final` class is a `BytecodeTransformerBuildItem` that strips the `final` flag at class-load time within the (test) application classloader. This doesn't touch the original jar and is scoped to this build only.
-6. `WorkflowClient`/`WorkerFactory` in mock mode aren't only consumed by test classes — they're the *same* beans application code under test (REST resources, services) injects. A fix limited to patching the test class's own fields (rejected alternative, see below) would leave application code stale after the first test.
+2. **`io.temporal.worker.WorkerFactory` is a `final` class with only a `private` 2-argument constructor** (`WorkerFactory(WorkflowClient, WorkerFactoryOptions)`, verified via `javap`), and no no-arg constructor. `TestWorkflowEnvironment` and `WorkflowClient` are interfaces.
+3. **CDI field injection into a `@QuarkusTest` instance happens at test-instance construction time** (`QuarkusTestExtension.interceptTestClassConstructor`), which runs *before* any `QuarkusTestBeforeEachCallback`/`QuarkusTestAfterConstructCallback` fires. A plain re-assignment of a bean's backing value in a `BeforeEachCallback` would be too late to affect an already-injected raw field reference — unless the injected reference is a *proxy* whose delegate can be swapped after the fact, or unless the fresh value is already in place *before* that construction happens.
+4. Quarkus already solves the proxy-swap half of (3) elsewhere: `io.quarkus.test.junit.QuarkusMock` (`installMockForType`/`installMockForInstance`) swaps what a **normal-scoped** bean's client proxy delegates to, for the duration of one test, and this is exactly how `@InjectMock`/Mockito support works internally (`SetMockitoMockAsBeanMockCallback`, a `QuarkusTestBeforeEachCallback`, uses it). `QuarkusTestExtension.beforeEach()` calls `pushMockContext()` *before* invoking `QuarkusTestBeforeEachCallback`s, and `afterEach()` calls `popMockContext()` after ours — so mock installs made inside our callback are automatically test-scoped with no manual cleanup needed. This works cleanly for `TestWorkflowEnvironment`/`WorkflowClient` (interfaces).
+5. **`WorkerFactory` cannot use the same proxy mechanism.** CDI/ArC's client-proxy generator (`io.quarkus.arc.processor.ClientProxyGenerator`) subclasses the bean's own concrete class when it isn't an interface, and its generated constructor calls `invokeSpecial(ConstructorDesc.of(superClass), ...)` — a **no-arg** super constructor call. `WorkerFactory` has no no-arg constructor, and its only constructor is `private` (uncallable even from hand-written subclassing code). Quarkus's usual trick for a merely-`final` third-party class (`BytecodeTransformerBuildItem` stripping `ACC_FINAL`, as seen in `quarkus-grpc`'s `FieldDefinalizingVisitor`) does not solve this — it only addresses the `final` flag, not the missing/private constructor. Synthesizing a working no-arg constructor via ASM was considered and rejected as too invasive/risky for this change (see Approaches below).
+6. `WorkflowClient`/`WorkerFactory` in mock mode aren't only consumed by test classes — they're the *same* beans application code under test (REST resources, services) injects. A fix limited to patching the test class's own fields (rejected alternative, see below) would leave application code stale after the first test. In practice `WorkflowClient` is the far more common injection point for application business logic; `WorkerFactory` is primarily a test/infrastructure concern.
 
 ## Approaches considered
 
 **Rejected: reflection-based field patching on the test class only.** A `QuarkusTestAfterConstructCallback` could reflectively overwrite `@Inject`-annotated fields of the three types directly on the test instance (the same technique `@InjectMock` uses for its final field-set step, minus the CDI-wide override). Simpler, no bytecode transform needed — but only fixes the test class's own fields. Any application bean that also injects `WorkflowClient`/`WorkerFactory` (the extension's core mock-mode use case) stays bound to a stale instance after the first test. Rejected because it doesn't fully fix the reported problem class.
 
-**Chosen: CDI normal-scope proxy swap via `QuarkusMock`, with `WorkerFactory` de-finalized via bytecode transform.** More code, touches both `extension/runtime` and `test-extension`, but is the complete, general fix: it corrects staleness for the test class *and* for application code under test, using the same mechanism Quarkus's own mocking support relies on.
+**Rejected: ASM-synthesized no-arg constructor on `WorkerFactory` to unblock full CDI proxying.** Would let all three beans use the same clean `ApplicationScoped` + `QuarkusMock` mechanism uniformly. Rejected as too risky for this change: it requires injecting a brand-new constructor into third-party SDK bytecode that leaves the real (final) fields unassigned — verifiable at the JVM level, but unvalidated in this codebase and a meaningfully bigger surface for subtle breakage than the chosen approach, for a benefit (freshness when `WorkerFactory` is injected into a non-per-test-reconstructed application bean) that covers an uncommon case.
+
+**Chosen: hybrid — `QuarkusMock` proxy swap for `TestWorkflowEnvironment`/`WorkflowClient`, "prepare-ahead" `@Dependent` scope for `WorkerFactory`.** `TestWorkflowEnvironment` and `WorkflowClient` become `ApplicationScoped` and are swapped per test via `QuarkusMock`, exactly as originally designed. `WorkerFactory` instead becomes `@Dependent`-scoped, with its producer reading "whatever is currently prepared" from a plain holder — no proxy needed, so the constructor problem never arises. The timing gap this creates (CDI resolves `@Dependent` fields at test-construction time, *before* `beforeEach` can run) is closed by preparing test N+1's environment during test N's `afterEach`, not test N+1's `beforeEach` — so by the time the next test is constructed and its `@Dependent WorkerFactory` field resolves, the fresh instance is already sitting in the holder. `beforeEach` then installs that *same* already-prepared instance into `QuarkusMock` for the other two beans, keeping all three identity-consistent. This fully fixes the reported bug (`WorkerFactory` injected directly into the `@QuarkusTest` class, which is reconstructed per test method) and fully fixes `WorkflowClient` freshness everywhere, including application code under test. It leaves one narrow, documented gap: an `@ApplicationScoped` *production* bean that injects `WorkerFactory` directly (not the test class, not another per-test-reconstructed bean) would still see only the boot-time instance.
 
 ## Design
 
@@ -29,45 +31,44 @@ Goal: make the extension-provided `TestWorkflowEnvironment`/`WorkflowClient`/`Wo
 
 | Component | Module | Change |
 |---|---|---|
-| `TestWorkflowEnvironment`, `WorkflowClient`, `WorkerFactory` synthetic beans | `test-extension/deployment` | Scope `Singleton` → `ApplicationScoped`. Creation logic (`createWith`) unchanged — still builds the initial instance at boot. |
-| New `BuildStep` producing `BytecodeTransformerBuildItem` | `test-extension/deployment` | Strips `final` off `io.temporal.worker.WorkerFactory`'s class bytecode, gated `onlyIf = TemporalProcessor.EnableMock`. No effect on production (non-mock) builds. |
+| `TestWorkflowEnvironment`, `WorkflowClient` synthetic beans | `test-extension/deployment` | Scope `Singleton` → `ApplicationScoped`. |
+| `WorkerFactory` synthetic bean | `test-extension/deployment` | Scope `Singleton` → `Dependent`. `createWith` reads `MockTestEnvironmentHolder.current().getWorkerFactory()` instead of building anything itself. |
+| `MockTestEnvironmentHolder` (new) | `test-extension/runtime` | Plain static holder (not a CDI bean) storing the "currently prepared" `TestWorkflowEnvironment` for the in-progress or upcoming test. |
 | `WorkerRegistrationRegistry` (new) | `extension/runtime` | Static registry of replay closures: `(name, workflows, activities) -> WorkerFactoryRecorder.doCreateWorker(...)`. Populated unconditionally (cheap — a handful of class references), read only by `test-extension`. |
-| `WorkerFactoryRecorder.createWorker(...)` | `extension/runtime` | Existing logic extracted into a `doCreateWorker(...)` core method; the public `createWorker(...)` (called once at boot by `TemporalProcessor.setupWorkerFactory`) now also appends a replay closure to `WorkerRegistrationRegistry` before delegating to `doCreateWorker`. |
+| `WorkerFactoryRecorder.createWorker(...)` | `extension/runtime` | Existing logic extracted into a `doCreateWorker(...)` core method; the public `createWorker(...)` (called once at boot by `TemporalProcessor.setupWorkerFactory`, and replayed later by `test-extension`) now also appends a replay closure to `WorkerRegistrationRegistry` before delegating to `doCreateWorker`. |
 | `MockTestWorkflowResetCallback` (new) | `test-extension/runtime` | Implements both `QuarkusTestBeforeEachCallback` and `QuarkusTestAfterEachCallback`. See lifecycle below. |
 | `test-extension/runtime` `pom.xml` | `test-extension/runtime` | New dependency: `io.quarkus:quarkus-junit5` (compile scope — this module is already test-classpath-only by design). |
 | `META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback` and `...QuarkusTestAfterEachCallback` | `test-extension/runtime` | New service registrations for auto-discovery — zero user test-code changes required. |
 
-No changes to the production (non-mock) code paths in `extension`. The production `WorkerFactory` synthetic bean (`extension/deployment`, `onlyIfNot EnableMock`) is untouched.
+No changes to the production (non-mock) code paths in `extension`. The production `WorkerFactory` synthetic bean (`extension/deployment`, `onlyIfNot EnableMock`) is untouched. No bytecode transforms anywhere in this design.
 
 ### Per-test lifecycle
 
-**App boot (once, `RUNTIME_INIT` — unchanged except bean scope):**
-1. `TestWorkflowRecorder.createTestWorkflowEnvironment()` builds the initial `TestWorkflowEnvironment` via `TestEnvironmentOptions` (unchanged logic).
-2. `TemporalProcessor.setupWorkerFactory` calls `WorkerFactoryRecorder.createWorker(name, workflows, activities)` per declared worker — unchanged behavior, now also records a replay closure.
+**App boot (once, `RUNTIME_INIT`):**
+1. `TestWorkflowRecorder.createTestWorkflowEnvironment()` builds the initial `TestWorkflowEnvironment` via `TestEnvironmentOptions` (unchanged construction logic), and now also seeds it into `MockTestEnvironmentHolder` so it's available the moment anything (including the `@Dependent WorkerFactory` producer) asks for "current".
+2. `TemporalProcessor.setupWorkerFactory` calls `WorkerFactoryRecorder.createWorker(name, workflows, activities)` per declared worker — unchanged behavior, now also records a replay closure. Since `WorkerFactory` now resolves via the holder, this registers against the same instance just seeded in step 1.
 3. If `quarkus.temporal.start-workers=true`, the existing `startWorkers` build step starts the boot-time `WorkerFactory` (unchanged).
 
 **Before each `@Test` method — `MockTestWorkflowResetCallback.beforeEach(QuarkusTestMethodContext ctx)`:**
-1. Build a fresh `TestWorkflowEnvironment` (same `TestEnvironmentOptions` construction logic as `TestWorkflowRecorder`, extracted to a shared method).
-2. `QuarkusMock.installMockForType(freshEnv, TestWorkflowEnvironment.class)`.
-3. `QuarkusMock.installMockForType(freshEnv.getWorkflowClient(), WorkflowClient.class)`.
-4. `QuarkusMock.installMockForType(freshEnv.getWorkerFactory(), WorkerFactory.class)`.
-5. Replay every entry in `WorkerRegistrationRegistry` — each closure calls `WorkerFactoryRecorder.doCreateWorker(...)`, which resolves `WorkerFactory` via `CDI.current().select(WorkerFactory.class).get()`. Because that now returns the proxy installed in step 4, workers and workflow implementation types are recreated against the fresh factory exactly as they were at boot.
-6. If `start-workers=true`, call `freshWorkerFactory.start()` directly (no retry/background-retry machinery — that exists for real gRPC connectivity, not an in-memory test double). If `false` (the common mock-testing case, as used throughout PR #233's `unit-tests` module), leave it unstarted so the test can register mocked activities and call `testEnv.start()` itself.
-7. Track the fresh `TestWorkflowEnvironment`/`WorkerFactory` on the callback instance so `afterEach` closes the right one.
+1. Read `MockTestEnvironmentHolder.current()` — already prepared, either by app boot (test #1) or by the *previous* test's `afterEach` (test #2+). Do not build anything new here.
+2. `QuarkusMock.installMockForType(current, TestWorkflowEnvironment.class)`.
+3. `QuarkusMock.installMockForType(current.getWorkflowClient(), WorkflowClient.class)`.
+4. Track `current` on the callback instance as "the environment in use for this test" so `afterEach` tears down the right one.
+
+(No `QuarkusMock` install needed for `WorkerFactory` — as a `@Dependent` bean it was already resolved fresh, from the same holder, at this test's construction time, before `beforeEach` even ran.)
 
 **After each `@Test` method — `MockTestWorkflowResetCallback.afterEach(...)`:**
-1. `workerFactory.shutdown()`, guarded (log at `debug` and continue on failure — a test that already shut it down manually in its own `finally` block must not fail the next test's setup).
-2. `testEnv.close()`, same guard.
-3. Clear the tracked instance.
+1. Tear down the environment tracked in step 4 above: `inUse.getWorkerFactory().shutdown()` (guarded), then `inUse.close()` (guarded) — a test that already closed things manually in its own `finally` block (like the existing `Failure1Test`/`Failure2Test` patterns) must not fail this step.
+2. Prepare the *next* one: build a fresh `TestWorkflowEnvironment` (same `TestEnvironmentOptions` logic as boot), replay every entry in `WorkerRegistrationRegistry` against its `getWorkerFactory()` — each closure calls `WorkerFactoryRecorder.doCreateWorker(...)`, which resolves `WorkerFactory` via `CDI.current().select(WorkerFactory.class).get()`, which (as `@Dependent`) reads the holder and gets this new instance. If `start-workers=true`, call `freshWorkerFactory.start()` directly (no retry/background-retry machinery — that exists for real gRPC connectivity, not an in-memory test double); if `false` (the common mock-testing case, as used throughout PR #233's `unit-tests` module), leave it unstarted so the next test can register mocked activities and call `testEnv.start()` itself.
+3. Store the freshly-prepared instance via `MockTestEnvironmentHolder.set(...)`.
 
-`QuarkusTestExtension.afterEach()`'s own `popMockContext()` clears the `QuarkusMock` overrides automatically — no extra cleanup needed for that part.
+One bounded loose end: after the *last* test in a run, this still prepares one more environment that's never consumed or explicitly torn down — reclaimed at JVM exit. Acceptable for an in-memory test double; not worth a `QuarkusTestAfterAllCallback` for this change.
 
 ### Error handling
 
-- Teardown failures in `afterEach` are logged and swallowed (not propagated) — see above.
-- Replay failures in `beforeEach` (e.g. a workflow implementation that can't be instantiated) propagate normally, failing that test method — matching how a boot-time registration failure fails app startup today.
+- Teardown failures in `afterEach` step 1 are logged (`debug`) and swallowed, not propagated — see above.
+- Replay/prepare failures in `afterEach` step 2 (e.g. a workflow implementation that can't be instantiated) propagate normally, failing whichever test triggered them — matching how a boot-time registration failure fails app startup today.
 - `QuarkusMock.installMockForType` failures (e.g. a bean unexpectedly not normal-scoped) are not caught — that would indicate an extension bug, not a user-facing condition.
-- The `BytecodeTransformerBuildItem` is `onlyIf = EnableMock`, so it never runs for production builds.
 
 ## Testing plan
 
@@ -80,5 +81,6 @@ No changes to the production (non-mock) code paths in `extension`. The productio
 
 ## Open questions / risks
 
-- The `BytecodeTransformerBuildItem` approach to de-finalizing `WorkerFactory` is a known Quarkus technique but hasn't been exercised in this codebase before; worth validating early in implementation that ArC accepts the transformed class for proxy generation without further tweaks (e.g. if any individual methods ArC needs to override are themselves `final`, though unlikely for a class that's only class-level `final`).
+- The "prepare-ahead" timing (build test N+1's environment during test N's `afterEach`) is a real but slightly unusual pattern; it must be implemented carefully so the very first test (prepared at boot, not in an `afterEach`) and the very last test (whose prepared successor is never consumed) both behave correctly — covered explicitly in the lifecycle and testing sections above.
+- Documented, accepted gap: an `@ApplicationScoped` *production* bean (not the test class, not another per-test-reconstructed bean) that injects `WorkerFactory` directly still only ever sees the boot-time instance. Worth a line in the extension's testing docs.
 - `unit-tests` (PR #233's demonstration module) is currently a standalone proof-of-concept the PR author suggested *not* merging as-is ("my preference would be not to merge this into the project but just to update the docs"). This design assumes we adapt its test classes into the extension's own test suite rather than merging the module verbatim — worth confirming with the PR author before finalizing which files move where.

--- a/docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md
+++ b/docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md
@@ -1,0 +1,84 @@
+# Per-Test-Fresh Mock TestWorkflowEnvironment — Design
+
+## Problem
+
+PR [#233](https://github.com/quarkiverse/quarkus-temporal/pull/233) (author: michael-read) demonstrates that `TestWorkflowEnvironment`, `WorkflowClient`, and `WorkerFactory` — the beans produced by `quarkus-temporal-test` when `quarkus.temporal.enable-mock=true` — are registered as `@Singleton`-scoped CDI synthetic beans, created once at `RUNTIME_INIT`. Quarkus reuses the same application instance across all `@QuarkusTest` classes in a JVM run, so every test method in every test class receives the *same* `TestWorkflowEnvironment` instance.
+
+This is fatal for any test suite with more than one test method that exercises a workflow to completion: `TestWorkflowEnvironment` is a single-use, stateful in-memory Temporal server. A test that calls `testEnv.close()` (a normal cleanup step, and the pattern used throughout the `unit-tests` module added in PR #233) leaves every subsequent test with a closed, unusable environment. Temporal's own `TestWorkflowExtension` (a JUnit5 `BeforeEachCallback`) avoids this by constructing a brand-new `TestWorkflowEnvironment` per test method — this is the difference PR #233's `OrderEntityWorkflowMultiTestSuccessTest` demonstrates by bypassing the extension's injected beans entirely and using the Temporal Test Kit directly.
+
+Goal: make the extension-provided `TestWorkflowEnvironment`/`WorkflowClient`/`WorkerFactory` behave the same way — fresh per test method — without requiring any change to user test code (no `@RegisterExtension` boilerplate), and without losing the extension's auto-discovery of workflow implementation types/workers.
+
+## Constraints discovered during investigation
+
+1. **Worker/workflow-type registration is also a one-time boot step.** `TemporalProcessor.setupWorkerFactory` (a `@Record(RUNTIME_INIT)` build step) calls `WorkerFactoryRecorder.createWorker(name, workflows, activities)` once per declared worker, against whatever `WorkerFactory` bean exists at that moment. A naive "swap the environment" fix would leave every subsequent test's fresh `WorkerFactory` with zero registered workers/workflow types.
+2. **`io.temporal.worker.WorkerFactory` is a `final` class.** CDI/ArC cannot generate a normal-scope client proxy for a final class (subclassing is required and impossible). `TestWorkflowEnvironment` and `WorkflowClient` are interfaces and are proxyable.
+3. **CDI field injection into a `@QuarkusTest` instance happens at test-instance construction time** (`QuarkusTestExtension.interceptTestClassConstructor`), which runs *before* any `QuarkusTestBeforeEachCallback`/`QuarkusTestAfterConstructCallback` fires. A plain re-assignment of a bean's backing value in a `BeforeEachCallback` would be too late to affect an already-injected raw field reference — unless the injected reference is a *proxy* whose delegate can be swapped after the fact.
+4. Quarkus already solves both (2) and (3) elsewhere: `io.quarkus.test.junit.QuarkusMock` (`installMockForType`/`installMockForInstance`) swaps what a **normal-scoped** bean's client proxy delegates to, for the duration of one test, and this is exactly how `@InjectMock`/Mockito support works internally (`SetMockitoMockAsBeanMockCallback`, a `QuarkusTestBeforeEachCallback`, uses it). `QuarkusTestExtension.beforeEach()` calls `pushMockContext()` *before* invoking `QuarkusTestBeforeEachCallback`s, and `afterEach()` calls `popMockContext()` after ours — so mock installs made inside our callback are automatically test-scoped with no manual cleanup needed.
+5. Quarkus's standard technique for proxying a third-party `final` class is a `BytecodeTransformerBuildItem` that strips the `final` flag at class-load time within the (test) application classloader. This doesn't touch the original jar and is scoped to this build only.
+6. `WorkflowClient`/`WorkerFactory` in mock mode aren't only consumed by test classes — they're the *same* beans application code under test (REST resources, services) injects. A fix limited to patching the test class's own fields (rejected alternative, see below) would leave application code stale after the first test.
+
+## Approaches considered
+
+**Rejected: reflection-based field patching on the test class only.** A `QuarkusTestAfterConstructCallback` could reflectively overwrite `@Inject`-annotated fields of the three types directly on the test instance (the same technique `@InjectMock` uses for its final field-set step, minus the CDI-wide override). Simpler, no bytecode transform needed — but only fixes the test class's own fields. Any application bean that also injects `WorkflowClient`/`WorkerFactory` (the extension's core mock-mode use case) stays bound to a stale instance after the first test. Rejected because it doesn't fully fix the reported problem class.
+
+**Chosen: CDI normal-scope proxy swap via `QuarkusMock`, with `WorkerFactory` de-finalized via bytecode transform.** More code, touches both `extension/runtime` and `test-extension`, but is the complete, general fix: it corrects staleness for the test class *and* for application code under test, using the same mechanism Quarkus's own mocking support relies on.
+
+## Design
+
+### Components
+
+| Component | Module | Change |
+|---|---|---|
+| `TestWorkflowEnvironment`, `WorkflowClient`, `WorkerFactory` synthetic beans | `test-extension/deployment` | Scope `Singleton` → `ApplicationScoped`. Creation logic (`createWith`) unchanged — still builds the initial instance at boot. |
+| New `BuildStep` producing `BytecodeTransformerBuildItem` | `test-extension/deployment` | Strips `final` off `io.temporal.worker.WorkerFactory`'s class bytecode, gated `onlyIf = TemporalProcessor.EnableMock`. No effect on production (non-mock) builds. |
+| `WorkerRegistrationRegistry` (new) | `extension/runtime` | Static registry of replay closures: `(name, workflows, activities) -> WorkerFactoryRecorder.doCreateWorker(...)`. Populated unconditionally (cheap — a handful of class references), read only by `test-extension`. |
+| `WorkerFactoryRecorder.createWorker(...)` | `extension/runtime` | Existing logic extracted into a `doCreateWorker(...)` core method; the public `createWorker(...)` (called once at boot by `TemporalProcessor.setupWorkerFactory`) now also appends a replay closure to `WorkerRegistrationRegistry` before delegating to `doCreateWorker`. |
+| `MockTestWorkflowResetCallback` (new) | `test-extension/runtime` | Implements both `QuarkusTestBeforeEachCallback` and `QuarkusTestAfterEachCallback`. See lifecycle below. |
+| `test-extension/runtime` `pom.xml` | `test-extension/runtime` | New dependency: `io.quarkus:quarkus-junit5` (compile scope — this module is already test-classpath-only by design). |
+| `META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback` and `...QuarkusTestAfterEachCallback` | `test-extension/runtime` | New service registrations for auto-discovery — zero user test-code changes required. |
+
+No changes to the production (non-mock) code paths in `extension`. The production `WorkerFactory` synthetic bean (`extension/deployment`, `onlyIfNot EnableMock`) is untouched.
+
+### Per-test lifecycle
+
+**App boot (once, `RUNTIME_INIT` — unchanged except bean scope):**
+1. `TestWorkflowRecorder.createTestWorkflowEnvironment()` builds the initial `TestWorkflowEnvironment` via `TestEnvironmentOptions` (unchanged logic).
+2. `TemporalProcessor.setupWorkerFactory` calls `WorkerFactoryRecorder.createWorker(name, workflows, activities)` per declared worker — unchanged behavior, now also records a replay closure.
+3. If `quarkus.temporal.start-workers=true`, the existing `startWorkers` build step starts the boot-time `WorkerFactory` (unchanged).
+
+**Before each `@Test` method — `MockTestWorkflowResetCallback.beforeEach(QuarkusTestMethodContext ctx)`:**
+1. Build a fresh `TestWorkflowEnvironment` (same `TestEnvironmentOptions` construction logic as `TestWorkflowRecorder`, extracted to a shared method).
+2. `QuarkusMock.installMockForType(freshEnv, TestWorkflowEnvironment.class)`.
+3. `QuarkusMock.installMockForType(freshEnv.getWorkflowClient(), WorkflowClient.class)`.
+4. `QuarkusMock.installMockForType(freshEnv.getWorkerFactory(), WorkerFactory.class)`.
+5. Replay every entry in `WorkerRegistrationRegistry` — each closure calls `WorkerFactoryRecorder.doCreateWorker(...)`, which resolves `WorkerFactory` via `CDI.current().select(WorkerFactory.class).get()`. Because that now returns the proxy installed in step 4, workers and workflow implementation types are recreated against the fresh factory exactly as they were at boot.
+6. If `start-workers=true`, call `freshWorkerFactory.start()` directly (no retry/background-retry machinery — that exists for real gRPC connectivity, not an in-memory test double). If `false` (the common mock-testing case, as used throughout PR #233's `unit-tests` module), leave it unstarted so the test can register mocked activities and call `testEnv.start()` itself.
+7. Track the fresh `TestWorkflowEnvironment`/`WorkerFactory` on the callback instance so `afterEach` closes the right one.
+
+**After each `@Test` method — `MockTestWorkflowResetCallback.afterEach(...)`:**
+1. `workerFactory.shutdown()`, guarded (log at `debug` and continue on failure — a test that already shut it down manually in its own `finally` block must not fail the next test's setup).
+2. `testEnv.close()`, same guard.
+3. Clear the tracked instance.
+
+`QuarkusTestExtension.afterEach()`'s own `popMockContext()` clears the `QuarkusMock` overrides automatically — no extra cleanup needed for that part.
+
+### Error handling
+
+- Teardown failures in `afterEach` are logged and swallowed (not propagated) — see above.
+- Replay failures in `beforeEach` (e.g. a workflow implementation that can't be instantiated) propagate normally, failing that test method — matching how a boot-time registration failure fails app startup today.
+- `QuarkusMock.installMockForType` failures (e.g. a bean unexpectedly not normal-scoped) are not caught — that would indicate an extension bug, not a user-facing condition.
+- The `BytecodeTransformerBuildItem` is `onlyIf = EnableMock`, so it never runs for production builds.
+
+## Testing plan
+
+1. **Regression proof**: bring in `OrderEntityWorkflowMultiTestFailure1Test` and `OrderEntityWorkflowMultiTestFailure2Test` from PR #233 (renamed appropriately) and confirm both test methods in each class pass when run together — the direct proof this fixes the reported bug.
+2. **`test-extension/deployment` unit tests** (`QuarkusUnitTest`-based, matching existing module style):
+   - Multiple `@Test` methods directly injecting `TestWorkflowEnvironment`/`WorkflowClient`/`WorkerFactory`, asserting the instances differ across methods and that one test's workflow history is invisible to the next.
+   - `start-workers=true`: assert the fresh factory is auto-started each test. Investigate why the existing `StartWorkersEnabledTest`/`StartWorkersDisabledTest` are currently `@Disabled` (no explanation in history) and re-enable if this fix resolves whatever was blocking them — not a hard requirement of this change, but worth checking.
+   - A case proving the *application-code* path: a plain `@ApplicationScoped` CDI bean (not the test class) injects `WorkflowClient`, and two test methods confirm it resolves the current per-test client each time.
+3. Full existing `extension` + `test-extension` suite must stay green — this change must not alter production (non-mock) behavior.
+
+## Open questions / risks
+
+- The `BytecodeTransformerBuildItem` approach to de-finalizing `WorkerFactory` is a known Quarkus technique but hasn't been exercised in this codebase before; worth validating early in implementation that ArC accepts the transformed class for proxy generation without further tweaks (e.g. if any individual methods ArC needs to override are themselves `final`, though unlikely for a class that's only class-level `final`).
+- `unit-tests` (PR #233's demonstration module) is currently a standalone proof-of-concept the PR author suggested *not* merging as-is ("my preference would be not to merge this into the project but just to update the docs"). This design assumes we adapt its test classes into the extension's own test suite rather than merging the module verbatim — worth confirming with the PR author before finalizing which files move where.

--- a/docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md
+++ b/docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md
@@ -31,7 +31,7 @@ Goal: make the extension-provided `TestWorkflowEnvironment`/`WorkflowClient`/`Wo
 
 | Component | Module | Change |
 |---|---|---|
-| `TestWorkflowEnvironment`, `WorkflowClient` synthetic beans | `test-extension/deployment` | Scope `Singleton` → `ApplicationScoped`. |
+| `TestWorkflowEnvironment` synthetic bean | `test-extension/deployment` | Scope `Singleton` → `ApplicationScoped`. (`WorkflowClient`'s bean is already `ApplicationScoped` today — no scope change needed there, just the new `QuarkusMock` install.) |
 | `WorkerFactory` synthetic bean | `test-extension/deployment` | Scope `Singleton` → `Dependent`. `createWith` reads `MockTestEnvironmentHolder.current().getWorkerFactory()` instead of building anything itself. |
 | `MockTestEnvironmentHolder` (new) | `test-extension/runtime` | Plain static holder (not a CDI bean) storing the "currently prepared" `TestWorkflowEnvironment` for the in-progress or upcoming test. |
 | `WorkerRegistrationRegistry` (new) | `extension/runtime` | Static registry of replay closures: `(name, workflows, activities) -> WorkerFactoryRecorder.doCreateWorker(...)`. Populated unconditionally (cheap — a handful of class references), read only by `test-extension`. |
@@ -72,12 +72,12 @@ One bounded loose end: after the *last* test in a run, this still prepares one m
 
 ## Testing plan
 
-1. **Regression proof**: bring in `OrderEntityWorkflowMultiTestFailure1Test` and `OrderEntityWorkflowMultiTestFailure2Test` from PR #233 (renamed appropriately) and confirm both test methods in each class pass when run together — the direct proof this fixes the reported bug.
-2. **`test-extension/deployment` unit tests** (`QuarkusUnitTest`-based, matching existing module style):
-   - Multiple `@Test` methods directly injecting `TestWorkflowEnvironment`/`WorkflowClient`/`WorkerFactory`, asserting the instances differ across methods and that one test's workflow history is invisible to the next.
-   - `start-workers=true`: assert the fresh factory is auto-started each test. Investigate why the existing `StartWorkersEnabledTest`/`StartWorkersDisabledTest` are currently `@Disabled` (no explanation in history) and re-enable if this fix resolves whatever was blocking them — not a hard requirement of this change, but worth checking.
-   - A case proving the *application-code* path: a plain `@ApplicationScoped` CDI bean (not the test class) injects `WorkflowClient`, and two test methods confirm it resolves the current per-test client each time.
-3. Full existing `extension` + `test-extension` suite must stay green — this change must not alter production (non-mock) behavior.
+**Important mechanism note discovered during implementation planning:** `test-extension/deployment`'s existing test suite (`MockEnabledTest`, `StartWorkersEnabledTest`, etc.) uses `io.quarkus.test.QuarkusUnitTest`, a lighter-weight harness for testing build steps in-process. Its `beforeEach`/`afterEach` do **not** invoke the `QuarkusTestBeforeEachCallback`/`QuarkusTestAfterEachCallback` SPI at all (confirmed by reading its source) — so this fix's callback would never fire in a `QuarkusUnitTest`-based test, and such a test would prove nothing about it. The regression/behavioral tests for this fix must instead live in the `integration-tests` module, which already depends on `quarkus-temporal-test` and already has real `@QuarkusTest` classes (`CDIActivityIT`, `MoneyTransferIT`) that go through the full `QuarkusTestExtension` lifecycle, including our callback.
+
+1. **Regression proof** (new, in `integration-tests`): a `@QuarkusTest` IT class with two `@Order`ed test methods against a small new trivial workflow (no activities needed — `integration-tests`' default `start-workers=true` auto-registers it). Each method runs the workflow, then explicitly closes it (`workerFactory.shutdown()` + `testEnv.close()`) in a `finally` block — reproducing PR #233's exact `Failure2Test` pattern. Before the fix, the second method would fail immediately (stale, already-closed environment); after the fix, it gets a working fresh one.
+2. **Application-code freshness**, folded into the same IT class: a small `@ApplicationScoped` CDI bean (not the test class) injects `WorkflowClient`; each test method asserts it resolves to the *current* test's client (`== testEnv.getWorkflowClient()`), proving the fix isn't limited to the test class's own fields.
+3. Investigate why the existing `test-extension/deployment` `StartWorkersEnabledTest`/`StartWorkersDisabledTest` are currently `@Disabled` (no explanation in history) — separate from this fix, worth a quick look, not a hard requirement.
+4. Full existing `extension` + `test-extension` + `integration-tests` suite must stay green — this change must not alter production (non-mock) behavior, and existing IT classes (which don't explicitly close the environment) must keep working with a fresh-per-test environment.
 
 ## Open questions / risks
 

--- a/extension/deployment/src/main/java/io/quarkiverse/temporal/deployment/TemporalProcessor.java
+++ b/extension/deployment/src/main/java/io/quarkiverse/temporal/deployment/TemporalProcessor.java
@@ -379,7 +379,7 @@ public class TemporalProcessor {
 
     }
 
-    @BuildStep
+    @BuildStep(onlyIfNot = EnableMock.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void produceWorkflowStubSyntheticBeans(
             BuildProducer<SyntheticBeanBuildItem> producer,

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerFactoryRecorder.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerFactoryRecorder.java
@@ -195,7 +195,14 @@ public class WorkerFactoryRecorder {
 
     public void createWorker(String name, List<Class<?>> workflows,
             List<Class<?>> activities) {
-        // Workers are created during runtime init and registered with workflow/activity implementations.
+        WorkerRegistrationRegistry.record(() -> doCreateWorker(name, workflows, activities));
+        doCreateWorker(name, workflows, activities);
+    }
+
+    private void doCreateWorker(String name, List<Class<?>> workflows,
+            List<Class<?>> activities) {
+        // Workers are created during runtime init (or replayed per test in mock mode) and
+        // registered with workflow/activity implementations.
         // Starting polling threads is intentionally deferred to startWorkerFactory(...).
         WorkerFactory workerFactory = CDI.current().select(WorkerFactory.class).get();
         WorkerRuntimeConfig workerRuntimeConfig = runtimeConfig.getValue().worker().get(name);

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerRegistrationRegistry.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerRegistrationRegistry.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.temporal;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Captures worker/workflow-type registrations performed at boot so they can be replayed
+ * against a freshly created {@link io.temporal.worker.WorkerFactory} in test/mock mode.
+ *
+ * Populated unconditionally by {@link WorkerFactoryRecorder#createWorker}; only ever read
+ * by the {@code quarkus-temporal-test} extension.
+ */
+public final class WorkerRegistrationRegistry {
+
+    private static final List<Runnable> REGISTRATIONS = new CopyOnWriteArrayList<>();
+
+    private WorkerRegistrationRegistry() {
+    }
+
+    public static void record(Runnable registration) {
+        REGISTRATIONS.add(registration);
+    }
+
+    public static void replayAll() {
+        for (Runnable registration : REGISTRATIONS) {
+            registration.run();
+        }
+    }
+}

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowClientOptionsSupport.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowClientOptionsSupport.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.util.TypeLiteral;
 
 import io.quarkus.arc.SyntheticCreationalContext;
@@ -25,14 +26,41 @@ public final class WorkflowClientOptionsSupport {
             String namespace,
             Optional<String> identity) {
 
+        Instance<DataConverter> dataConverterInstance = context.getInjectedReference(new TypeLiteral<>() {
+        }, Any.Literal.INSTANCE);
+        Instance<WorkflowClientInterceptor> interceptorInstance = context.getInjectedReference(new TypeLiteral<>() {
+        }, Any.Literal.INSTANCE);
+        Instance<ContextPropagator> contextPropagatorInstance = context.getInjectedReference(new TypeLiteral<>() {
+        }, Any.Literal.INSTANCE);
+
+        return build(namespace, identity, dataConverterInstance, interceptorInstance, contextPropagatorInstance);
+    }
+
+    /**
+     * Same result as {@link #buildFromContext}, but resolvable outside of synthetic bean
+     * creation (e.g. from a JUnit test-lifecycle callback), using {@link CDI#current()} directly.
+     */
+    public static WorkflowClientOptions buildFromCurrentCdi(String namespace, Optional<String> identity) {
+        Instance<DataConverter> dataConverterInstance = CDI.current().select(DataConverter.class, Any.Literal.INSTANCE);
+        Instance<WorkflowClientInterceptor> interceptorInstance = CDI.current().select(WorkflowClientInterceptor.class,
+                Any.Literal.INSTANCE);
+        Instance<ContextPropagator> contextPropagatorInstance = CDI.current().select(ContextPropagator.class,
+                Any.Literal.INSTANCE);
+
+        return build(namespace, identity, dataConverterInstance, interceptorInstance, contextPropagatorInstance);
+    }
+
+    private static WorkflowClientOptions build(
+            String namespace,
+            Optional<String> identity,
+            Instance<DataConverter> dataConverterInstance,
+            Instance<WorkflowClientInterceptor> interceptorInstance,
+            Instance<ContextPropagator> contextPropagatorInstance) {
+
         WorkflowClientOptions.Builder builder = WorkflowClientOptions.newBuilder()
                 .setNamespace(namespace);
 
         identity.ifPresent(builder::setIdentity);
-
-        // obtain the data converter from CDI at runtime if available
-        Instance<DataConverter> dataConverterInstance = context.getInjectedReference(new TypeLiteral<>() {
-        }, Any.Literal.INSTANCE);
 
         DataConverter dataConverter = dataConverterInstance.isResolvable()
                 ? dataConverterInstance.get()
@@ -42,20 +70,12 @@ public final class WorkflowClientOptionsSupport {
             builder.setDataConverter(dataConverter);
         }
 
-        // discover interceptors
-        Instance<WorkflowClientInterceptor> interceptorInstance = context.getInjectedReference(new TypeLiteral<>() {
-        }, Any.Literal.INSTANCE);
-
         List<WorkflowClientInterceptor> interceptors = interceptorInstance.stream()
                 .collect(Collectors.toCollection(ArrayList::new));
 
         if (!interceptors.isEmpty()) {
             builder.setInterceptors(interceptors.toArray(new WorkflowClientInterceptor[0]));
         }
-
-        // discover propagators
-        Instance<ContextPropagator> contextPropagatorInstance = context.getInjectedReference(new TypeLiteral<>() {
-        }, Any.Literal.INSTANCE);
 
         List<ContextPropagator> propagators = contextPropagatorInstance.stream()
                 .collect(Collectors.toCollection(ArrayList::new));

--- a/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowStubRecorder.java
+++ b/extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowStubRecorder.java
@@ -54,7 +54,7 @@ public class WorkflowStubRecorder {
         return builder.build();
     }
 
-    <T> WorkflowOptions createWorkflowOptions(SyntheticCreationalContext<T> context, String worker, String workflowId) {
+    public <T> WorkflowOptions createWorkflowOptions(SyntheticCreationalContext<T> context, String worker, String workflowId) {
 
         InjectionPoint injectionPoint = context.getInjectedReference(InjectionPoint.class);
         TemporalWorkflowStub annotation = extractAnnotationFromInjectionPoint(injectionPoint);

--- a/integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/FreshnessClientHolder.java
+++ b/integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/FreshnessClientHolder.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.temporal.it.freshness;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.temporal.client.WorkflowClient;
+
+/**
+ * Stands in for ordinary application code (a REST resource, a service) that injects
+ * {@link WorkflowClient} once and is never reconstructed per test - unlike the test class
+ * itself, which JUnit reconstructs for every test method.
+ */
+@ApplicationScoped
+public class FreshnessClientHolder {
+
+    @Inject
+    WorkflowClient workflowClient;
+
+    public WorkflowClient get() {
+        return workflowClient;
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/defaultWorker/FreshnessWorkflow.java
+++ b/integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/defaultWorker/FreshnessWorkflow.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.temporal.it.freshness.defaultWorker;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface FreshnessWorkflow {
+
+    @WorkflowMethod
+    String ping(String input);
+}

--- a/integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/defaultWorker/FreshnessWorkflowImpl.java
+++ b/integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/defaultWorker/FreshnessWorkflowImpl.java
@@ -1,0 +1,9 @@
+package io.quarkiverse.temporal.it.freshness.defaultWorker;
+
+public class FreshnessWorkflowImpl implements FreshnessWorkflow {
+
+    @Override
+    public String ping(String input) {
+        return "pong:" + input;
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowEnvironmentFreshnessIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowEnvironmentFreshnessIT.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.temporal.it;
+
+import static io.quarkiverse.temporal.Constants.DEFAULT_WORKER_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkiverse.temporal.it.freshness.FreshnessClientHolder;
+import io.quarkiverse.temporal.it.freshness.defaultWorker.FreshnessWorkflow;
+import io.quarkus.test.junit.QuarkusTest;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowEnvironment;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestWorkflowEnvironmentFreshnessIT {
+
+    @Inject
+    TestWorkflowEnvironment testEnv;
+
+    @Inject
+    FreshnessClientHolder applicationBean;
+
+    @Test
+    @Order(1)
+    public void firstTestRunsAndClosesTheEnvironment() {
+        runAndClose("first");
+    }
+
+    @Test
+    @Order(2)
+    public void secondTestGetsAFreshEnvironment() {
+        // Before the fix, this method received the same, already-closed
+        // TestWorkflowEnvironment as the first test, and testEnv.getWorkerFactory()
+        // below would already be shut down.
+        runAndClose("second");
+    }
+
+    private void runAndClose(String input) {
+        // Uses the client injected into an application-code-style CDI bean (not the test
+        // class's own field) to prove the fix isn't limited to the test class's fields.
+        // If this client were stale, newWorkflowStub/ping below would fail or hang against
+        // a different (or already-closed) in-memory environment.
+        WorkflowClient current = applicationBean.get();
+        FreshnessWorkflow workflow = current.newWorkflowStub(FreshnessWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(DEFAULT_WORKER_NAME).build());
+        try {
+            assertEquals("pong:" + input, workflow.ping(input));
+        } finally {
+            testEnv.getWorkerFactory().shutdown();
+            testEnv.close();
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowStubFreshnessIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowStubFreshnessIT.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.temporal.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkiverse.temporal.TemporalWorkflowStub;
+import io.quarkiverse.temporal.it.freshness.defaultWorker.FreshnessWorkflow;
+import io.quarkus.test.junit.QuarkusTest;
+import io.temporal.testing.TestWorkflowEnvironment;
+
+/**
+ * Reproduces PR #233's Failure3Test pattern: a field-injected
+ * {@code @TemporalWorkflowStub} workflow stub (rather than one built by hand from
+ * an injected {@code WorkflowClient}), used across two ordered test methods that
+ * each explicitly close the environment.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestWorkflowStubFreshnessIT {
+
+    @Inject
+    TestWorkflowEnvironment testEnv;
+
+    @Inject
+    @TemporalWorkflowStub
+    FreshnessWorkflow workflow;
+
+    @Test
+    @Order(1)
+    public void firstTestRunsAndClosesTheEnvironment() {
+        runAndClose("first");
+    }
+
+    @Test
+    @Order(2)
+    public void secondTestGetsAFreshEnvironment() {
+        runAndClose("second");
+    }
+
+    private void runAndClose(String input) {
+        try {
+            assertEquals("pong:" + input, workflow.ping(input));
+        } finally {
+            testEnv.getWorkerFactory().shutdown();
+            testEnv.close();
+        }
+    }
+}

--- a/test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
+++ b/test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
@@ -1,18 +1,25 @@
 package io.quarkiverse.temporal.test.deployment;
 
 import static io.quarkiverse.temporal.Constants.TEMPORAL_TESTING_CAPABILITY;
+import static io.quarkiverse.temporal.deployment.TemporalProcessor.TEMPORAL_INSTANCE;
+
+import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.ParameterizedType;
 
+import io.quarkiverse.temporal.TemporalWorkflowStub;
 import io.quarkiverse.temporal.deployment.TemporalProcessor;
+import io.quarkiverse.temporal.deployment.WorkflowBuildItem;
 import io.quarkiverse.temporal.test.TestWorkflowRecorder;
+import io.quarkiverse.temporal.test.TestWorkflowStubRecorder;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -98,5 +105,84 @@ public class TemporalTestProcessor {
                 .createWith(recorder.createTestWorkerFactory())
                 .setRuntimeInit()
                 .done();
+    }
+
+    @BuildStep(onlyIf = TemporalProcessor.EnableMock.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void produceWorkflowStubSyntheticBeans(
+            BuildProducer<SyntheticBeanBuildItem> producer,
+            List<WorkflowBuildItem> workflowImplBuildItems,
+            TestWorkflowStubRecorder recorder) {
+        // Mock-mode counterpart of TemporalProcessor#produceWorkflowStubSyntheticBeans: same set
+        // of @TemporalWorkflowStub-qualified @Dependent beans, but resolving the WorkflowClient
+        // from MockTestEnvironmentHolder (prepared one test ahead) instead of injecting the CDI
+        // WorkflowClient bean directly - see TestWorkflowStubRecorder for why.
+        for (WorkflowBuildItem workflowBuildItem : workflowImplBuildItems) {
+            if (workflowBuildItem.workers.length == 1) {
+
+                producer.produce(
+                        SyntheticBeanBuildItem.configure(TEMPORAL_INSTANCE)
+                                .types(ParameterizedType.create(TEMPORAL_INSTANCE,
+                                        ClassType.create(workflowBuildItem.workflow)))
+                                .scope(Dependent.class)
+                                .addInjectionPoint(ClassType.create(InjectionPoint.class))
+                                .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
+                                .addQualifier()
+                                .annotation(TemporalWorkflowStub.class)
+                                .addValue("worker", TemporalWorkflowStub.DEFAULT_WORKER)
+                                .done()
+                                .createWith(
+                                        recorder.createWorkflowInstance(workflowBuildItem.workflow,
+                                                workflowBuildItem.workers[0]))
+                                .setRuntimeInit()
+                                .done());
+
+                producer.produce(
+                        SyntheticBeanBuildItem.configure(workflowBuildItem.workflow)
+                                .scope(Dependent.class)
+                                .addInjectionPoint(ClassType.create(InjectionPoint.class))
+                                .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
+                                .addQualifier()
+                                .annotation(TemporalWorkflowStub.class)
+                                .addValue("worker", TemporalWorkflowStub.DEFAULT_WORKER)
+                                .done()
+                                .createWith(
+                                        recorder.createWorkflowStub(workflowBuildItem.workflow, workflowBuildItem.workers[0]))
+                                .setRuntimeInit()
+                                .done());
+            }
+
+            for (String worker : workflowBuildItem.workers) {
+
+                producer.produce(
+                        SyntheticBeanBuildItem.configure(TEMPORAL_INSTANCE)
+                                .types(ParameterizedType.create(TEMPORAL_INSTANCE,
+                                        ClassType.create(workflowBuildItem.workflow)))
+                                .scope(Dependent.class)
+                                .addInjectionPoint(ClassType.create(InjectionPoint.class))
+                                .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
+                                .addQualifier()
+                                .annotation(TemporalWorkflowStub.class)
+                                .addValue("worker", worker)
+                                .done()
+                                .createWith(
+                                        recorder.createWorkflowInstance(workflowBuildItem.workflow, worker))
+                                .setRuntimeInit()
+                                .done());
+
+                producer.produce(
+                        SyntheticBeanBuildItem.configure(workflowBuildItem.workflow)
+                                .scope(Dependent.class)
+                                .addInjectionPoint(ClassType.create(InjectionPoint.class))
+                                .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
+                                .addQualifier()
+                                .annotation(TemporalWorkflowStub.class)
+                                .addValue("worker", worker)
+                                .done()
+                                .createWith(recorder.createWorkflowStub(workflowBuildItem.workflow, worker))
+                                .setRuntimeInit()
+                                .done());
+            }
+        }
     }
 }

--- a/test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
+++ b/test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
@@ -3,9 +3,9 @@ package io.quarkiverse.temporal.test.deployment;
 import static io.quarkiverse.temporal.Constants.TEMPORAL_TESTING_CAPABILITY;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Singleton;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
@@ -46,7 +46,7 @@ public class TemporalTestProcessor {
     SyntheticBeanBuildItem recordTestEnvironment(TestWorkflowRecorder recorder) {
         return SyntheticBeanBuildItem
                 .configure(TestWorkflowEnvironment.class)
-                .scope(Singleton.class)
+                .scope(ApplicationScoped.class)
                 .unremovable()
                 .addInjectionPoint(
                         ParameterizedType.create(Instance.class, ClassType.create(WorkflowClientInterceptor.class)),
@@ -80,13 +80,21 @@ public class TemporalTestProcessor {
     @BuildStep(onlyIf = TemporalProcessor.EnableMock.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     SyntheticBeanBuildItem produceWorkerFactorySyntheticBean(TestWorkflowRecorder recorder) {
+        // @Dependent (not a normal scope): io.temporal.worker.WorkerFactory is a final class
+        // with only a private constructor and cannot be CDI-proxied. A fresh instance is
+        // instead resolved from MockTestEnvironmentHolder at every injection point - see
+        // MockTestEnvironmentHolder / MockTestWorkflowResetCallback for how freshness is
+        // still achieved per test.
+        // The TestWorkflowEnvironment injection point below is not read directly by
+        // createTestWorkerFactory() any more, but it must stay: declaring it is what forces
+        // ArC to create the TestWorkflowEnvironment bean (and so seed the holder) before this
+        // bean is ever created.
         return SyntheticBeanBuildItem
                 .configure(WorkerFactory.class)
-                .scope(Singleton.class)
+                .scope(Dependent.class)
                 .unremovable()
                 .defaultBean()
                 .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
-                .addInjectionPoint(ClassType.create(WorkflowClient.class))
                 .createWith(recorder.createTestWorkerFactory())
                 .setRuntimeInit()
                 .done();

--- a/test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersDisabledTest.java
+++ b/test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersDisabledTest.java
@@ -6,14 +6,12 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.temporal.worker.WorkerFactory;
 
-@Disabled
 class StartWorkersDisabledTest {
 
     @RegisterExtension

--- a/test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersEnabledTest.java
+++ b/test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersEnabledTest.java
@@ -8,7 +8,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -16,7 +15,6 @@ import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
 import io.temporal.worker.WorkerFactory;
 
-@Disabled
 class StartWorkersEnabledTest {
 
     @RegisterExtension

--- a/test-extension/runtime/pom.xml
+++ b/test-extension/runtime/pom.xml
@@ -26,6 +26,11 @@
             <groupId>io.temporal</groupId>
             <artifactId>temporal-testing</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestEnvironmentHolder.java
+++ b/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestEnvironmentHolder.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.temporal.test;
+
+import io.temporal.testing.TestWorkflowEnvironment;
+
+/**
+ * Holds the {@link TestWorkflowEnvironment} currently prepared for the in-progress (or
+ * about-to-start) test. Deliberately a plain static holder, not a CDI bean, so the
+ * {@code @Dependent}-scoped {@code WorkerFactory} synthetic bean can read it at CDI
+ * injection time - which happens at test-instance construction, before any JUnit
+ * lifecycle callback has a chance to run.
+ */
+public final class MockTestEnvironmentHolder {
+
+    private static volatile TestWorkflowEnvironment current;
+
+    private MockTestEnvironmentHolder() {
+    }
+
+    public static TestWorkflowEnvironment current() {
+        return current;
+    }
+
+    public static void set(TestWorkflowEnvironment environment) {
+        current = environment;
+    }
+}

--- a/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestWorkflowResetCallback.java
+++ b/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestWorkflowResetCallback.java
@@ -1,0 +1,105 @@
+package io.quarkiverse.temporal.test;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.temporal.WorkerRegistrationRegistry;
+import io.quarkiverse.temporal.WorkflowClientOptionsSupport;
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+import io.temporal.client.WorkflowClient;
+import io.temporal.testing.TestEnvironmentOptions;
+import io.temporal.testing.TestWorkflowEnvironment;
+
+/**
+ * Gives every {@code @Test} method its own {@link TestWorkflowEnvironment} (and derived
+ * {@link WorkflowClient}/{@link io.temporal.worker.WorkerFactory}) instead of the single,
+ * shared, leaking instance the extension previously handed out for the whole test JVM run.
+ *
+ * <p>
+ * {@code TestWorkflowEnvironment} and {@code WorkflowClient} are swapped per test via
+ * {@link QuarkusMock}. {@code WorkerFactory} cannot use the same mechanism (it's a final SDK
+ * class with only a private constructor, so ArC can't generate a client proxy for it) - it is
+ * instead {@code @Dependent}-scoped and reads the "currently prepared" environment from
+ * {@link MockTestEnvironmentHolder}, which this callback prepares one test ahead: CDI resolves
+ * {@code @Dependent} fields at test-construction time, before {@link #beforeEach} can run, so
+ * the fresh instance has to already be in the holder by then.
+ */
+public class MockTestWorkflowResetCallback implements QuarkusTestBeforeEachCallback, QuarkusTestAfterEachCallback {
+
+    private static final Logger log = Logger.getLogger(MockTestWorkflowResetCallback.class);
+
+    private TestWorkflowEnvironment inUseForCurrentTest;
+
+    @Override
+    public void beforeEach(QuarkusTestMethodContext context) {
+        if (!isMockEnabled()) {
+            return;
+        }
+        // Already prepared - by app boot (the very first test) or by the previous test's
+        // afterEach (every test after that).
+        TestWorkflowEnvironment current = MockTestEnvironmentHolder.current();
+        if (current == null) {
+            return;
+        }
+        QuarkusMock.installMockForType(current, TestWorkflowEnvironment.class);
+        QuarkusMock.installMockForType(current.getWorkflowClient(), WorkflowClient.class);
+        this.inUseForCurrentTest = current;
+    }
+
+    @Override
+    public void afterEach(QuarkusTestMethodContext context) {
+        if (!isMockEnabled()) {
+            return;
+        }
+        TestWorkflowEnvironment justUsed = this.inUseForCurrentTest;
+        this.inUseForCurrentTest = null;
+        if (justUsed != null) {
+            shutdownQuietly(justUsed);
+        }
+        prepareNext();
+    }
+
+    private void prepareNext() {
+        TestEnvironmentOptions options = TestEnvironmentOptions.newBuilder()
+                .setWorkflowClientOptions(WorkflowClientOptionsSupport.buildFromCurrentCdi("default", Optional.empty()))
+                .build();
+        TestWorkflowEnvironment next = TestWorkflowEnvironment.newInstance(options);
+
+        MockTestEnvironmentHolder.set(next);
+        WorkerRegistrationRegistry.replayAll();
+
+        if (isStartWorkersEnabled()) {
+            next.getWorkerFactory().start();
+        }
+    }
+
+    private void shutdownQuietly(TestWorkflowEnvironment environment) {
+        try {
+            environment.getWorkerFactory().shutdown();
+        } catch (RuntimeException e) {
+            log.debugf(e, "Ignoring failure shutting down worker factory - likely already shut down by the test");
+        }
+        try {
+            environment.close();
+        } catch (RuntimeException e) {
+            log.debugf(e, "Ignoring failure closing test workflow environment - likely already closed by the test");
+        }
+    }
+
+    private static boolean isMockEnabled() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.temporal.enable-mock", Boolean.class)
+                .orElse(false);
+    }
+
+    private static boolean isStartWorkersEnabled() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.temporal.start-workers", Boolean.class)
+                .orElse(false);
+    }
+}

--- a/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java
+++ b/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java
@@ -20,7 +20,11 @@ public class TestWorkflowRecorder {
                     .setWorkflowClientOptions(createTestWorkflowClientOptions(context))
                     .build();
 
-            return TestWorkflowEnvironment.newInstance(options);
+            TestWorkflowEnvironment environment = TestWorkflowEnvironment.newInstance(options);
+            // Seed the holder immediately: the @Dependent WorkerFactory bean (and the
+            // first test's MockTestWorkflowResetCallback) both read from it.
+            MockTestEnvironmentHolder.set(environment);
+            return environment;
         };
     }
 
@@ -42,9 +46,6 @@ public class TestWorkflowRecorder {
     }
 
     public Function<SyntheticCreationalContext<WorkerFactory>, WorkerFactory> createTestWorkerFactory() {
-        return context -> {
-            TestWorkflowEnvironment testWorkflowEnvironment = context.getInjectedReference(TestWorkflowEnvironment.class);
-            return testWorkflowEnvironment.getWorkerFactory();
-        };
+        return context -> MockTestEnvironmentHolder.current().getWorkerFactory();
     }
 }

--- a/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java
+++ b/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java
@@ -46,6 +46,15 @@ public class TestWorkflowRecorder {
     }
 
     public Function<SyntheticCreationalContext<WorkerFactory>, WorkerFactory> createTestWorkerFactory() {
-        return context -> MockTestEnvironmentHolder.current().getWorkerFactory();
+        return context -> {
+            // TestWorkflowEnvironment is ApplicationScoped (proxied): merely obtaining the
+            // injected reference does not trigger its creation, only invoking a method on it
+            // does. That first creation is what seeds MockTestEnvironmentHolder, which is
+            // then read below (not the value returned here) so later tests - which swap the
+            // holder directly - are picked up too.
+            TestWorkflowEnvironment testWorkflowEnvironment = context.getInjectedReference(TestWorkflowEnvironment.class);
+            testWorkflowEnvironment.getWorkerFactory();
+            return MockTestEnvironmentHolder.current().getWorkerFactory();
+        };
     }
 }

--- a/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowStubRecorder.java
+++ b/test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowStubRecorder.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.temporal.test;
+
+import java.util.function.Function;
+
+import io.quarkiverse.temporal.TemporalInstance;
+import io.quarkiverse.temporal.WorkflowStubRecorder;
+import io.quarkiverse.temporal.config.TemporalBuildtimeConfig;
+import io.quarkiverse.temporal.config.TemporalRuntimeConfig;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.temporal.client.WorkflowClient;
+import io.temporal.testing.TestWorkflowEnvironment;
+
+/**
+ * Mock-mode counterpart of {@link WorkflowStubRecorder}. A {@code @TemporalWorkflowStub}-qualified
+ * bean is {@code @Dependent}, so it's (re)created every time it's injected - including into a test
+ * class's own fields, which CDI resolves at test-instance construction time, before
+ * {@link MockTestWorkflowResetCallback#beforeEach} has a chance to swap in the next test's
+ * {@link WorkflowClient} via {@code QuarkusMock}. Building the stub against the CDI-injected
+ * {@code WorkflowClient} reference at that point would bind it to the *previous* test's
+ * (possibly already-closed) client. Instead, resolve the client directly from
+ * {@link MockTestEnvironmentHolder}, which is always prepared one test ahead - see
+ * {@link MockTestWorkflowResetCallback} for how.
+ */
+@Recorder
+public class TestWorkflowStubRecorder {
+
+    private final WorkflowStubRecorder delegate;
+
+    public TestWorkflowStubRecorder(RuntimeValue<TemporalRuntimeConfig> runtimeConfig,
+            TemporalBuildtimeConfig buildtimeConfig) {
+        this.delegate = new WorkflowStubRecorder(runtimeConfig, buildtimeConfig);
+    }
+
+    public <T> Function<SyntheticCreationalContext<TemporalInstance<T>>, TemporalInstance<T>> createWorkflowInstance(
+            Class<T> workflow, String worker) {
+        return context -> workflowId -> currentWorkflowClient(context)
+                .newWorkflowStub(workflow, delegate.createWorkflowOptions(context, worker, workflowId));
+    }
+
+    public <T> Function<SyntheticCreationalContext<T>, T> createWorkflowStub(Class<T> workflow, String worker) {
+        return context -> currentWorkflowClient(context)
+                .newWorkflowStub(workflow, delegate.createWorkflowOptions(context, worker, null));
+    }
+
+    private <T> WorkflowClient currentWorkflowClient(SyntheticCreationalContext<T> context) {
+        // TestWorkflowEnvironment is ApplicationScoped (proxied): merely obtaining the injected
+        // reference does not trigger its creation, only invoking a method on it does. That first
+        // creation is what seeds MockTestEnvironmentHolder for the very first test, which is then
+        // read below (not the value returned here) so later tests - which swap the holder
+        // directly ahead of test-instance construction - are picked up too.
+        context.getInjectedReference(TestWorkflowEnvironment.class).getWorkflowClient();
+        return MockTestEnvironmentHolder.current().getWorkflowClient();
+    }
+}

--- a/test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
+++ b/test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
@@ -1,0 +1,1 @@
+io.quarkiverse.temporal.test.MockTestWorkflowResetCallback

--- a/test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
+++ b/test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
@@ -1,0 +1,1 @@
+io.quarkiverse.temporal.test.MockTestWorkflowResetCallback


### PR DESCRIPTION
# Per-Test-Fresh Mock TestWorkflowEnvironment Implementation Plan

**Goal:** Make `quarkus-temporal-test`'s injected `TestWorkflowEnvironment`/`WorkflowClient`/`WorkerFactory` fresh for every `@Test` method instead of one shared, leaking, `Singleton`-scoped instance for the whole test JVM run — fixing the bug demonstrated in [PR #233](https://github.com/quarkiverse/quarkus-temporal/pull/233) — without requiring any change to user test code.

**Architecture:** `TestWorkflowEnvironment` becomes `ApplicationScoped` and `WorkflowClient` stays `ApplicationScoped` (already was); both get swapped per test via `QuarkusMock.installMockForType(...)` in a new `QuarkusTestBeforeEachCallback`. `WorkerFactory` is a `final` SDK class with only a `private` constructor and can't be CDI-proxied, so it becomes `@Dependent`-scoped instead, reading "whatever is currently prepared" from a plain static holder; a "prepare-ahead" `QuarkusTestAfterEachCallback` builds test N+1's environment during test N's teardown so it's already in the holder by the time test N+1 is constructed (CDI resolves `@Dependent` fields at construction time, before any callback can run). Worker/workflow-type registration (normally a one-time boot step) is captured as replayable closures and re-run against every fresh environment.

**Tech Stack:** Quarkus 3.33.1 (Java, Maven multi-module), Temporal Java SDK (`temporal-sdk`, `temporal-testing`), JUnit 5, `quarkus-junit`'s test-lifecycle callback SPI (`io.quarkus.test.junit.callback.*`), Mockito (test-only, for the fixture regression coverage).

**Spec:** `docs/superpowers/specs/2026-08-30-per-test-mock-environment-design.md`

## Global Constraints

- No changes to production (non-mock) code paths in `extension`. All new/changed behavior is gated behind `quarkus.temporal.enable-mock=true` (build-time) or is otherwise inert unless the `quarkus-temporal-test` extension is present.
- No bytecode transforms (`BytecodeTransformerBuildItem`) anywhere in this design — that approach was tried and rejected (see spec, "Constraints discovered during investigation" #5, and "Approaches considered").
- Every new dependency version comes from the existing `quarkus-bom` import (no explicit `<version>` needed for `quarkus-junit` or `mockito-core`).
- Regression/behavioral tests for the actual per-test-freshness fix MUST live in `integration-tests` (real `@QuarkusTest`, goes through the full `QuarkusTestExtension` lifecycle). `test-extension/deployment`'s `QuarkusUnitTest`-based tests do **not** invoke the `QuarkusTestBeforeEachCallback`/`QuarkusTestAfterEachCallback` SPI this fix relies on (verified by reading `QuarkusUnitTest`'s source) — a test written there would prove nothing about this fix.
- Follow existing code style: 4-space indent, no javadoc beyond what's shown below, package-private where the existing code is package-private.

---

### Task 1: Capture worker registration for replay (`extension/runtime`)

**Files:**
- Create: `extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerRegistrationRegistry.java`
- Modify: `extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerFactoryRecorder.java:196-214`

**Interfaces:**
- Produces: `WorkerRegistrationRegistry.record(Runnable)` and `WorkerRegistrationRegistry.replayAll()` — a static registry other modules (Task 6's callback) call into to re-run worker/workflow-type registration against a freshly created `WorkerFactory`.
- Consumes: nothing new; `WorkerFactoryRecorder`'s existing fields (`runtimeConfig`, `buildtimeConfig`) and existing private methods (`createWorkerOptions`, `createQueueName`) are unchanged.

This task has no externally-observable behavior change yet (worker creation logic is identical, just also recorded for later replay) — it's verified by confirming the existing test suite still passes.

- [x] **Step 1: Create the registry**

```java
package io.quarkiverse.temporal;

import java.util.List;
import java.util.concurrent.CopyOnWriteArrayList;

/**
 * Captures worker/workflow-type registrations performed at boot so they can be replayed
 * against a freshly created {@link io.temporal.worker.WorkerFactory} in test/mock mode.
 *
 * Populated unconditionally by {@link WorkerFactoryRecorder#createWorker}; only ever read
 * by the {@code quarkus-temporal-test} extension.
 */
public final class WorkerRegistrationRegistry {

    private static final List<Runnable> REGISTRATIONS = new CopyOnWriteArrayList<>();

    private WorkerRegistrationRegistry() {
    }

    public static void record(Runnable registration) {
        REGISTRATIONS.add(registration);
    }

    public static void replayAll() {
        for (Runnable registration : REGISTRATIONS) {
            registration.run();
        }
    }
}
```

- [x] **Step 2: Extract `createWorker`'s body into `doCreateWorker`, and record a replay closure**

In `WorkerFactoryRecorder.java`, replace the existing `createWorker` method (lines 196-214):

```java
    public void createWorker(String name, List<Class<?>> workflows,
            List<Class<?>> activities) {
        // Workers are created during runtime init and registered with workflow/activity implementations.
        // Starting polling threads is intentionally deferred to startWorkerFactory(...).
        WorkerFactory workerFactory = CDI.current().select(WorkerFactory.class).get();
        WorkerRuntimeConfig workerRuntimeConfig = runtimeConfig.getValue().worker().get(name);
        WorkerBuildtimeConfig workerBuildtimeConfig = buildtimeConfig.worker().get(name);

        Worker worker = workerFactory.newWorker(createQueueName(name, workerRuntimeConfig),
                createWorkerOptions(workerRuntimeConfig, workerBuildtimeConfig));
        for (var workflow : workflows) {
            worker.registerWorkflowImplementationTypes(workflow);
        }
        if (buildtimeConfig.startWorkers()) {
            for (var activity : activities) {
                worker.registerActivitiesImplementations(CDI.current().select(activity).get());
            }
        }
    }
```

with:

```java
    public void createWorker(String name, List<Class<?>> workflows,
            List<Class<?>> activities) {
        WorkerRegistrationRegistry.record(() -> doCreateWorker(name, workflows, activities));
        doCreateWorker(name, workflows, activities);
    }

    private void doCreateWorker(String name, List<Class<?>> workflows,
            List<Class<?>> activities) {
        // Workers are created during runtime init (or replayed per test in mock mode) and
        // registered with workflow/activity implementations.
        // Starting polling threads is intentionally deferred to startWorkerFactory(...).
        WorkerFactory workerFactory = CDI.current().select(WorkerFactory.class).get();
        WorkerRuntimeConfig workerRuntimeConfig = runtimeConfig.getValue().worker().get(name);
        WorkerBuildtimeConfig workerBuildtimeConfig = buildtimeConfig.worker().get(name);

        Worker worker = workerFactory.newWorker(createQueueName(name, workerRuntimeConfig),
                createWorkerOptions(workerRuntimeConfig, workerBuildtimeConfig));
        for (var workflow : workflows) {
            worker.registerWorkflowImplementationTypes(workflow);
        }
        if (buildtimeConfig.startWorkers()) {
            for (var activity : activities) {
                worker.registerActivitiesImplementations(CDI.current().select(activity).get());
            }
        }
    }
```

- [x] **Step 3: Build and run the existing extension test suite to confirm no regression**

Run: `mvn -q -pl extension/runtime,extension/deployment -am test`
Expected: BUILD SUCCESS, all existing tests pass (no behavior change yet).

- [x] **Step 4: Commit**

```bash
git add extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerRegistrationRegistry.java extension/runtime/src/main/java/io/quarkiverse/temporal/WorkerFactoryRecorder.java
git commit -m "feat: capture worker registration for replay in mock/test mode"
```

---

### Task 2: Add a CDI-current variant of `WorkflowClientOptionsSupport` (`extension/runtime`)

**Files:**
- Modify: `extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowClientOptionsSupport.java`

**Interfaces:**
- Produces: `WorkflowClientOptionsSupport.buildFromCurrentCdi(String namespace, Optional<String> identity)` — same result as `buildFromContext`, but resolvable outside of synthetic-bean creation (needed by Task 5's JUnit callback, which isn't inside a `SyntheticCreationalContext`).
- Consumes: nothing new.

- [x] **Step 1: Refactor to share logic between `buildFromContext` and a new `buildFromCurrentCdi`**

Replace the full contents of `WorkflowClientOptionsSupport.java` with:

```java
package io.quarkiverse.temporal;

import java.util.ArrayList;
import java.util.List;
import java.util.Optional;
import java.util.stream.Collectors;

import jakarta.enterprise.inject.Any;
import jakarta.enterprise.inject.Instance;
import jakarta.enterprise.inject.spi.CDI;
import jakarta.enterprise.util.TypeLiteral;

import io.quarkus.arc.SyntheticCreationalContext;
import io.temporal.client.WorkflowClientOptions;
import io.temporal.common.context.ContextPropagator;
import io.temporal.common.converter.DataConverter;
import io.temporal.common.interceptors.WorkflowClientInterceptor;

public final class WorkflowClientOptionsSupport {

    private WorkflowClientOptionsSupport() {
    }

    public static WorkflowClientOptions buildFromContext(
            SyntheticCreationalContext<?> context,
            String namespace,
            Optional<String> identity) {

        Instance<DataConverter> dataConverterInstance = context.getInjectedReference(new TypeLiteral<>() {
        }, Any.Literal.INSTANCE);
        Instance<WorkflowClientInterceptor> interceptorInstance = context.getInjectedReference(new TypeLiteral<>() {
        }, Any.Literal.INSTANCE);
        Instance<ContextPropagator> contextPropagatorInstance = context.getInjectedReference(new TypeLiteral<>() {
        }, Any.Literal.INSTANCE);

        return build(namespace, identity, dataConverterInstance, interceptorInstance, contextPropagatorInstance);
    }

    /**
     * Same result as {@link #buildFromContext}, but resolvable outside of synthetic bean
     * creation (e.g. from a JUnit test-lifecycle callback), using {@link CDI#current()} directly.
     */
    public static WorkflowClientOptions buildFromCurrentCdi(String namespace, Optional<String> identity) {
        Instance<DataConverter> dataConverterInstance = CDI.current().select(DataConverter.class, Any.Literal.INSTANCE);
        Instance<WorkflowClientInterceptor> interceptorInstance = CDI.current().select(WorkflowClientInterceptor.class,
                Any.Literal.INSTANCE);
        Instance<ContextPropagator> contextPropagatorInstance = CDI.current().select(ContextPropagator.class,
                Any.Literal.INSTANCE);

        return build(namespace, identity, dataConverterInstance, interceptorInstance, contextPropagatorInstance);
    }

    private static WorkflowClientOptions build(
            String namespace,
            Optional<String> identity,
            Instance<DataConverter> dataConverterInstance,
            Instance<WorkflowClientInterceptor> interceptorInstance,
            Instance<ContextPropagator> contextPropagatorInstance) {

        WorkflowClientOptions.Builder builder = WorkflowClientOptions.newBuilder()
                .setNamespace(namespace);

        identity.ifPresent(builder::setIdentity);

        DataConverter dataConverter = dataConverterInstance.isResolvable()
                ? dataConverterInstance.get()
                : null;

        if (dataConverter != null) {
            builder.setDataConverter(dataConverter);
        }

        List<WorkflowClientInterceptor> interceptors = interceptorInstance.stream()
                .collect(Collectors.toCollection(ArrayList::new));

        if (!interceptors.isEmpty()) {
            builder.setInterceptors(interceptors.toArray(new WorkflowClientInterceptor[0]));
        }

        List<ContextPropagator> propagators = contextPropagatorInstance.stream()
                .collect(Collectors.toCollection(ArrayList::new));
        if (!propagators.isEmpty()) {
            builder.setContextPropagators(propagators);
        }

        return builder.validateAndBuildWithDefaults();
    }
}
```

- [x] **Step 2: Build and run the existing extension + test-extension suite to confirm no regression**

Run: `mvn -q -pl extension/runtime,extension/deployment,test-extension/runtime,test-extension/deployment -am test`
Expected: BUILD SUCCESS, all existing tests pass.

- [x] **Step 3: Commit**

```bash
git add extension/runtime/src/main/java/io/quarkiverse/temporal/WorkflowClientOptionsSupport.java
git commit -m "refactor: extract CDI.current()-based variant of WorkflowClientOptionsSupport"
```

---

### Task 3: Add the prepare-ahead holder (`test-extension/runtime`)

**Files:**
- Create: `test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestEnvironmentHolder.java`
- Modify: `test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java`

**Interfaces:**
- Produces: `MockTestEnvironmentHolder.current()` (returns `TestWorkflowEnvironment`, may be `null` before boot seeding) and `MockTestEnvironmentHolder.set(TestWorkflowEnvironment)` — consumed by Task 4's `WorkerFactory` synthetic bean producer and Task 5's callback.
- Consumes: nothing new.

- [x] **Step 1: Create the holder**

```java
package io.quarkiverse.temporal.test;

import io.temporal.testing.TestWorkflowEnvironment;

/**
 * Holds the {@link TestWorkflowEnvironment} currently prepared for the in-progress (or
 * about-to-start) test. Deliberately a plain static holder, not a CDI bean, so the
 * {@code @Dependent}-scoped {@code WorkerFactory} synthetic bean can read it at CDI
 * injection time - which happens at test-instance construction, before any JUnit
 * lifecycle callback has a chance to run.
 */
public final class MockTestEnvironmentHolder {

    private static volatile TestWorkflowEnvironment current;

    private MockTestEnvironmentHolder() {
    }

    public static TestWorkflowEnvironment current() {
        return current;
    }

    public static void set(TestWorkflowEnvironment environment) {
        current = environment;
    }
}
```

- [x] **Step 2: Wire `TestWorkflowRecorder` to seed and read the holder**

Replace the full contents of `TestWorkflowRecorder.java` with:

```java
package io.quarkiverse.temporal.test;

import java.util.Optional;
import java.util.function.Function;

import io.quarkiverse.temporal.WorkflowClientOptionsSupport;
import io.quarkus.arc.SyntheticCreationalContext;
import io.quarkus.runtime.annotations.Recorder;
import io.temporal.client.WorkflowClient;
import io.temporal.client.WorkflowClientOptions;
import io.temporal.testing.TestEnvironmentOptions;
import io.temporal.testing.TestWorkflowEnvironment;
import io.temporal.worker.WorkerFactory;

@Recorder
public class TestWorkflowRecorder {
    public Function<SyntheticCreationalContext<TestWorkflowEnvironment>, TestWorkflowEnvironment> createTestWorkflowEnvironment() {
        return context -> {
            TestEnvironmentOptions options = TestEnvironmentOptions.newBuilder()
                    .setWorkflowClientOptions(createTestWorkflowClientOptions(context))
                    .build();

            TestWorkflowEnvironment environment = TestWorkflowEnvironment.newInstance(options);
            // Seed the holder immediately: the @Dependent WorkerFactory bean (and the
            // first test's MockTestWorkflowResetCallback) both read from it.
            MockTestEnvironmentHolder.set(environment);
            return environment;
        };
    }

    /**
     * Builds the {@link WorkflowClientOptions} used by the mock TestWorkflowEnvironment, while honoring the CDI wiring.
     */
    public WorkflowClientOptions createTestWorkflowClientOptions(SyntheticCreationalContext<?> context) {
        return WorkflowClientOptionsSupport.buildFromContext(
                context,
                "default",
                Optional.empty());
    }

    public Function<SyntheticCreationalContext<WorkflowClient>, WorkflowClient> createTestWorkflowClient() {
        return context -> {
            TestWorkflowEnvironment testWorkflowEnvironment = context.getInjectedReference(TestWorkflowEnvironment.class);
            return testWorkflowEnvironment.getWorkflowClient();
        };
    }

    public Function<SyntheticCreationalContext<WorkerFactory>, WorkerFactory> createTestWorkerFactory() {
        return context -> {
            // TestWorkflowEnvironment is ApplicationScoped (proxied): merely obtaining the
            // injected reference does not trigger its creation, only invoking a method on it
            // does. That first creation is what seeds MockTestEnvironmentHolder, which is
            // then read below (not the value returned here) so later tests - which swap the
            // holder directly - are picked up too.
            TestWorkflowEnvironment testWorkflowEnvironment = context.getInjectedReference(TestWorkflowEnvironment.class);
            testWorkflowEnvironment.getWorkerFactory();
            return MockTestEnvironmentHolder.current().getWorkerFactory();
        };
    }
}
```

- [x] **Step 3: Compile to confirm no errors (behavior not yet exercised until Task 4 changes the bean scopes)**

Run: `mvn -q -pl test-extension/runtime -am compile`
Expected: BUILD SUCCESS.

- [x] **Step 4: Commit**

```bash
git add test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestEnvironmentHolder.java test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/TestWorkflowRecorder.java
git commit -m "feat: add prepare-ahead holder for the mock TestWorkflowEnvironment"
```

---

### Task 4: Change synthetic bean scopes (`test-extension/deployment`)

**Files:**
- Modify: `test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java`

**Interfaces:**
- Consumes: `TestWorkflowRecorder.createTestWorkflowEnvironment()`, `.createTestWorkflowClient()`, `.createTestWorkerFactory()` (Task 3, unchanged signatures).
- Produces: the `TestWorkflowEnvironment`, `WorkflowClient`, `WorkerFactory` synthetic beans that Task 5's callback and Task 6's IT tests inject.

- [x] **Step 1: Change `TestWorkflowEnvironment`'s scope to `ApplicationScoped` and `WorkerFactory`'s scope to `Dependent`**

Replace the full contents of `TemporalTestProcessor.java` with:

```java
package io.quarkiverse.temporal.test.deployment;

import static io.quarkiverse.temporal.Constants.TEMPORAL_TESTING_CAPABILITY;

import jakarta.enterprise.context.ApplicationScoped;
import jakarta.enterprise.context.Dependent;
import jakarta.enterprise.inject.Any;
import jakarta.enterprise.inject.Instance;

import org.jboss.jandex.AnnotationInstance;
import org.jboss.jandex.ClassType;
import org.jboss.jandex.ParameterizedType;

import io.quarkiverse.temporal.deployment.TemporalProcessor;
import io.quarkiverse.temporal.test.TestWorkflowRecorder;
import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
import io.quarkus.deployment.annotations.BuildProducer;
import io.quarkus.deployment.annotations.BuildStep;
import io.quarkus.deployment.annotations.ExecutionTime;
import io.quarkus.deployment.annotations.Record;
import io.quarkus.deployment.builditem.CapabilityBuildItem;
import io.quarkus.deployment.builditem.FeatureBuildItem;
import io.temporal.client.WorkflowClient;
import io.temporal.common.context.ContextPropagator;
import io.temporal.common.converter.DataConverter;
import io.temporal.common.interceptors.WorkflowClientInterceptor;
import io.temporal.testing.TestWorkflowEnvironment;
import io.temporal.worker.WorkerFactory;

public class TemporalTestProcessor {

    private static final String FEATURE = "temporal-test";

    @BuildStep
    FeatureBuildItem feature() {
        return new FeatureBuildItem(FEATURE);
    }

    @BuildStep
    void capabilities(BuildProducer<CapabilityBuildItem> capabilityProducer) {
        capabilityProducer.produce(new CapabilityBuildItem(TEMPORAL_TESTING_CAPABILITY, "temporal"));
    }

    @Record(ExecutionTime.RUNTIME_INIT)
    @BuildStep(onlyIf = TemporalProcessor.EnableMock.class)
    SyntheticBeanBuildItem recordTestEnvironment(TestWorkflowRecorder recorder) {
        return SyntheticBeanBuildItem
                .configure(TestWorkflowEnvironment.class)
                .scope(ApplicationScoped.class)
                .unremovable()
                .addInjectionPoint(
                        ParameterizedType.create(Instance.class, ClassType.create(WorkflowClientInterceptor.class)),
                        AnnotationInstance.builder(Any.class).build())
                .addInjectionPoint(
                        ParameterizedType.create(Instance.class, ClassType.create(ContextPropagator.class)),
                        AnnotationInstance.builder(Any.class).build())
                .addInjectionPoint(
                        ParameterizedType.create(Instance.class, ClassType.create(DataConverter.class)),
                        AnnotationInstance.builder(Any.class).build())
                .createWith(recorder.createTestWorkflowEnvironment())
                .setRuntimeInit()
                .done();
    }

    @Record(ExecutionTime.RUNTIME_INIT)
    @BuildStep(onlyIf = TemporalProcessor.EnableMock.class)
    SyntheticBeanBuildItem recordWorkflowClient(TestWorkflowRecorder recorder) {

        return SyntheticBeanBuildItem
                .configure(WorkflowClient.class)
                .scope(ApplicationScoped.class)
                .unremovable()
                .defaultBean()
                .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
                .createWith(recorder.createTestWorkflowClient())
                .setRuntimeInit()
                .done();
    }

    @BuildStep(onlyIf = TemporalProcessor.EnableMock.class)
    @Record(ExecutionTime.RUNTIME_INIT)
    SyntheticBeanBuildItem produceWorkerFactorySyntheticBean(TestWorkflowRecorder recorder) {
        // @Dependent (not a normal scope): io.temporal.worker.WorkerFactory is a final class
        // with only a private constructor and cannot be CDI-proxied. A fresh instance is
        // instead resolved from MockTestEnvironmentHolder at every injection point - see
        // MockTestEnvironmentHolder / MockTestWorkflowResetCallback for how freshness is
        // still achieved per test.
        // The TestWorkflowEnvironment injection point below is not read directly by
        // createTestWorkerFactory() any more, but it must stay: declaring (and resolving) it
        // is what forces ArC to create the TestWorkflowEnvironment bean - and so seed the
        // holder - before this bean is ever created.
        return SyntheticBeanBuildItem
                .configure(WorkerFactory.class)
                .scope(Dependent.class)
                .unremovable()
                .defaultBean()
                .addInjectionPoint(ClassType.create(TestWorkflowEnvironment.class))
                .createWith(recorder.createTestWorkerFactory())
                .setRuntimeInit()
                .done();
    }
}
```

Note what changed from the original: `Singleton` import removed (no longer used), `Dependent` import added; `recordTestEnvironment`'s scope is now `ApplicationScoped`; `produceWorkerFactorySyntheticBean`'s scope is now `Dependent` (its `WorkflowClient` injection point, unused for the same reason, is removed - but its `TestWorkflowEnvironment` injection point must stay, see below).

**Discovered while implementing this task:** removing the `TestWorkflowEnvironment` injection point entirely broke boot - `WorkerFactoryRecorder.startWorkerFactory` resolves `WorkerFactory` before anything else forces `TestWorkflowEnvironment` to be created (e.g. in a test with no declared workers, nothing else ever touches it), so `MockTestEnvironmentHolder.current()` was `null`. Declaring the injection point isn't enough by itself either - `TestWorkflowEnvironment` is a normal-scoped (proxied) bean now, so merely obtaining the injected reference doesn't trigger creation, only invoking a method on it does (this is why `createTestWorkflowClient()` already worked unchanged - it calls `.getWorkflowClient()`). The fix, reflected in Task 3's final `createTestWorkerFactory()` above: keep the injection point, resolve it, and call `.getWorkerFactory()` on it (discarding the result) purely to force creation/holder-seeding, then read the actual return value from the holder.

- [x] **Step 2: Build and run the existing test-extension suite to confirm no regression**

Run: `mvn -q -pl test-extension/runtime,test-extension/deployment -am test`
Expected: BUILD SUCCESS, all existing tests (`MockEnabledTest`, etc.) pass. (`StartWorkersEnabledTest`/`StartWorkersDisabledTest` are pre-existing `@Disabled` tests, unaffected either way — see Task 7.)

- [x] **Step 3: Commit**

```bash
git add test-extension/deployment/src/main/java/io/quarkiverse/temporal/test/deployment/TemporalTestProcessor.java
git commit -m "fix: scope TestWorkflowEnvironment as ApplicationScoped, WorkerFactory as Dependent"
```

---

### Task 5: The per-test reset callback (`test-extension/runtime`)

**Files:**
- Modify: `test-extension/runtime/pom.xml`
- Create: `test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestWorkflowResetCallback.java`
- Create: `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback`
- Create: `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback`

**Interfaces:**
- Consumes: `MockTestEnvironmentHolder.current()`/`.set(...)` (Task 3), `WorkerRegistrationRegistry.replayAll()` (Task 1), `WorkflowClientOptionsSupport.buildFromCurrentCdi(...)` (Task 2).
- Produces: nothing new consumed by later tasks — this is the last piece of the production fix. Tasks 6/7 exercise it end-to-end.

- [x] **Step 1: Add the `quarkus-junit` dependency**

In `test-extension/runtime/pom.xml`, add inside `<dependencies>`:

```xml
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-junit</artifactId>
            <scope>provided</scope>
        </dependency>
```

**Discovered while implementing this task:** two corrections from what's written above.

First, `quarkus-junit5` (the artifact one might expect from older Quarkus docs) is not what provides `QuarkusMock`/the callback SPI in this Quarkus version (3.33.1) - `quarkus-junit` is, and it's also the artifact `integration-tests` already uses for its own `@QuarkusTest` classes, so this keeps the whole repo on one convention.

Second, `<scope>provided</scope>` is required, not optional: `quarkus-junit` (like `quarkus-junit5`) legitimately depends on `-deployment` artifacts (needed for `@QuarkusTest`'s own re-augmentation support), and the `quarkus-extension-maven-plugin`'s dependency verification step correctly rejects any `-deployment` artifact appearing on an extension runtime module's default (compile-scope) classpath - real consumers must never see build-time artifacts on their production classpath. `provided` scope makes the classes available for compiling this module without tripping that check. This doesn't leave consumers missing anything at runtime: anyone using `@QuarkusTest` (which is what's needed for this callback to ever run at all) already has `quarkus-junit` on their own test classpath directly, regardless of what `quarkus-temporal-test` declares.

- [x] **Step 2: Write the callback**

```java
package io.quarkiverse.temporal.test;

import java.util.Optional;

import org.eclipse.microprofile.config.ConfigProvider;
import org.jboss.logging.Logger;

import io.quarkiverse.temporal.WorkerRegistrationRegistry;
import io.quarkiverse.temporal.WorkflowClientOptionsSupport;
import io.quarkus.test.junit.QuarkusMock;
import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
import io.temporal.client.WorkflowClient;
import io.temporal.testing.TestEnvironmentOptions;
import io.temporal.testing.TestWorkflowEnvironment;

/**
 * Gives every {@code @Test} method its own {@link TestWorkflowEnvironment} (and derived
 * {@link WorkflowClient}/{@link io.temporal.worker.WorkerFactory}) instead of the single,
 * shared, leaking instance the extension previously handed out for the whole test JVM run.
 *
 * <p>{@code TestWorkflowEnvironment} and {@code WorkflowClient} are swapped per test via
 * {@link QuarkusMock}. {@code WorkerFactory} cannot use the same mechanism (it's a final SDK
 * class with only a private constructor, so ArC can't generate a client proxy for it) - it is
 * instead {@code @Dependent}-scoped and reads the "currently prepared" environment from
 * {@link MockTestEnvironmentHolder}, which this callback prepares one test ahead: CDI resolves
 * {@code @Dependent} fields at test-construction time, before {@link #beforeEach} can run, so
 * the fresh instance has to already be in the holder by then.
 */
public class MockTestWorkflowResetCallback implements QuarkusTestBeforeEachCallback, QuarkusTestAfterEachCallback {

    private static final Logger log = Logger.getLogger(MockTestWorkflowResetCallback.class);

    private TestWorkflowEnvironment inUseForCurrentTest;

    @Override
    public void beforeEach(QuarkusTestMethodContext context) {
        if (!isMockEnabled()) {
            return;
        }
        // Already prepared - by app boot (the very first test) or by the previous test's
        // afterEach (every test after that).
        TestWorkflowEnvironment current = MockTestEnvironmentHolder.current();
        if (current == null) {
            return;
        }
        QuarkusMock.installMockForType(current, TestWorkflowEnvironment.class);
        QuarkusMock.installMockForType(current.getWorkflowClient(), WorkflowClient.class);
        this.inUseForCurrentTest = current;
    }

    @Override
    public void afterEach(QuarkusTestMethodContext context) {
        if (!isMockEnabled()) {
            return;
        }
        TestWorkflowEnvironment justUsed = this.inUseForCurrentTest;
        this.inUseForCurrentTest = null;
        if (justUsed != null) {
            shutdownQuietly(justUsed);
        }
        prepareNext();
    }

    private void prepareNext() {
        TestEnvironmentOptions options = TestEnvironmentOptions.newBuilder()
                .setWorkflowClientOptions(WorkflowClientOptionsSupport.buildFromCurrentCdi("default", Optional.empty()))
                .build();
        TestWorkflowEnvironment next = TestWorkflowEnvironment.newInstance(options);

        MockTestEnvironmentHolder.set(next);
        WorkerRegistrationRegistry.replayAll();

        if (isStartWorkersEnabled()) {
            next.getWorkerFactory().start();
        }
    }

    private void shutdownQuietly(TestWorkflowEnvironment environment) {
        try {
            environment.getWorkerFactory().shutdown();
        } catch (RuntimeException e) {
            log.debugf(e, "Ignoring failure shutting down worker factory - likely already shut down by the test");
        }
        try {
            environment.close();
        } catch (RuntimeException e) {
            log.debugf(e, "Ignoring failure closing test workflow environment - likely already closed by the test");
        }
    }

    private static boolean isMockEnabled() {
        return ConfigProvider.getConfig()
                .getOptionalValue("quarkus.temporal.enable-mock", Boolean.class)
                .orElse(false);
    }

    private static boolean isStartWorkersEnabled() {
        return ConfigProvider.getConfig()
                .getOptionalValue("quarkus.temporal.start-workers", Boolean.class)
                .orElse(false);
    }
}
```

- [x] **Step 3: Register the callback for auto-discovery**

Create `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback` containing exactly:

```
io.quarkiverse.temporal.test.MockTestWorkflowResetCallback
```

Create `test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback` containing exactly:

```
io.quarkiverse.temporal.test.MockTestWorkflowResetCallback
```

- [x] **Step 4: Build and run the existing test-extension suite to confirm no regression**

Run: `mvn -q -pl test-extension/runtime,test-extension/deployment -am test`
Expected: BUILD SUCCESS. (Still no new *behavioral* proof yet - `test-extension/deployment`'s tests use `QuarkusUnitTest`, which doesn't invoke this callback at all. Task 6 is where this gets actually exercised.)

- [x] **Step 5: Commit**

```bash
git add test-extension/runtime/pom.xml test-extension/runtime/src/main/java/io/quarkiverse/temporal/test/MockTestWorkflowResetCallback.java test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback test-extension/runtime/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
git commit -m "feat: reset the mock TestWorkflowEnvironment before/after every test method"
```

---

### Task 6: Regression proof (`integration-tests`)

**Files:**
- Create: `integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/defaultWorker/FreshnessWorkflow.java`
- Create: `integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/defaultWorker/FreshnessWorkflowImpl.java`
- Create: `integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness/FreshnessClientHolder.java`
- Create: `integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowEnvironmentFreshnessIT.java`

**Interfaces:**
- Consumes: the fix from Tasks 1-5, exercised through ordinary `@Inject` — no direct code coupling, this task only proves behavior.

This module already depends on `quarkus-temporal-test` (test scope) and already has real `@QuarkusTest`/`*IT` classes (`CDIActivityIT`, `MoneyTransferIT`) using the module's default `application.properties` (`%test.quarkus.temporal.enable-mock=true`, `start-workers` defaulting to `true`). The new fixture is placed under a `defaultWorker` sub-package, mirroring the existing `it.cdi.defaultWorker`/`it.moneyTransfer.defaultWorker` convention that binds a workflow implementation to the extension's default worker - no new worker/task-queue config needed, and `start-workers=true` means the workflow gets auto-registered per test with no manual mock-activity setup required (this fixture needs no activities at all).

- [x] **Step 1: Add the trivial fixture workflow**

```java
package io.quarkiverse.temporal.it.freshness.defaultWorker;

import io.temporal.workflow.WorkflowInterface;
import io.temporal.workflow.WorkflowMethod;

@WorkflowInterface
public interface FreshnessWorkflow {

    @WorkflowMethod
    String ping(String input);
}
```

```java
package io.quarkiverse.temporal.it.freshness.defaultWorker;

public class FreshnessWorkflowImpl implements FreshnessWorkflow {

    @Override
    public String ping(String input) {
        return "pong:" + input;
    }
}
```

- [x] **Step 2: Add the application-code CDI bean that proves the fix isn't limited to the test class's own fields**

```java
package io.quarkiverse.temporal.it.freshness;

import jakarta.enterprise.context.ApplicationScoped;
import jakarta.inject.Inject;

import io.temporal.client.WorkflowClient;

/**
 * Stands in for ordinary application code (a REST resource, a service) that injects
 * {@link WorkflowClient} once and is never reconstructed per test - unlike the test class
 * itself, which JUnit reconstructs for every test method.
 */
@ApplicationScoped
public class FreshnessClientHolder {

    @Inject
    WorkflowClient workflowClient;

    public WorkflowClient get() {
        return workflowClient;
    }
}
```

- [x] **Step 3: Write the regression test**

```java
package io.quarkiverse.temporal.it;

import static io.quarkiverse.temporal.Constants.DEFAULT_WORKER_NAME;
import static org.junit.jupiter.api.Assertions.assertEquals;

import jakarta.inject.Inject;

import org.junit.jupiter.api.MethodOrderer;
import org.junit.jupiter.api.Order;
import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.TestMethodOrder;

import io.quarkiverse.temporal.it.freshness.FreshnessClientHolder;
import io.quarkiverse.temporal.it.freshness.defaultWorker.FreshnessWorkflow;
import io.quarkus.test.junit.QuarkusTest;
import io.temporal.client.WorkflowClient;
import io.temporal.client.WorkflowOptions;
import io.temporal.testing.TestWorkflowEnvironment;

@QuarkusTest
@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
public class TestWorkflowEnvironmentFreshnessIT {

    @Inject
    TestWorkflowEnvironment testEnv;

    @Inject
    FreshnessClientHolder applicationBean;

    @Test
    @Order(1)
    public void firstTestRunsAndClosesTheEnvironment() {
        runAndClose("first");
    }

    @Test
    @Order(2)
    public void secondTestGetsAFreshEnvironment() {
        // Before the fix, this method received the same, already-closed
        // TestWorkflowEnvironment as the first test, and testEnv.getWorkerFactory()
        // below would already be shut down.
        runAndClose("second");
    }

    private void runAndClose(String input) {
        // Uses the client injected into an application-code-style CDI bean (not the test
        // class's own field) to prove the fix isn't limited to the test class's fields.
        // If this client were stale, newWorkflowStub/ping below would fail or hang against
        // a different (or already-closed) in-memory environment.
        WorkflowClient current = applicationBean.get();
        FreshnessWorkflow workflow = current.newWorkflowStub(FreshnessWorkflow.class,
                WorkflowOptions.newBuilder().setTaskQueue(DEFAULT_WORKER_NAME).build());
        try {
            assertEquals("pong:" + input, workflow.ping(input));
        } finally {
            testEnv.getWorkerFactory().shutdown();
            testEnv.close();
        }
    }
}
```

**Discovered while implementing this task:** the original `assertSame(testEnv.getWorkflowClient(), applicationBean.get())` was a broken assertion, not a real check - `applicationBean.get()` returns a CDI client proxy (a stable, synthetic wrapper object), while `testEnv.getWorkflowClient()` returns the real underlying SDK object directly; the two are never reference-equal by design, regardless of whether the fix works. Removed it - the workflow call succeeding through `applicationBean.get()` is itself the meaningful proof (a stale client would be wired to a different, or already-closed, in-memory environment and the call would fail or hang).

- [x] **Step 4: Run the integration test suite**

Run: `mvn -q verify -pl integration-tests -am`
Expected: BUILD SUCCESS, both `testWorkflowEnvironmentFreshnessIT` methods pass. If this plan were executed against the *old* (pre-fix) code, `secondTestGetsAFreshEnvironment` would fail with an error indicating the worker factory/environment was already shut down - that's the regression this proves.

- [x] **Step 5: Commit**

```bash
git add integration-tests/src/main/java/io/quarkiverse/temporal/it/freshness integration-tests/src/test/java/io/quarkiverse/temporal/it/TestWorkflowEnvironmentFreshnessIT.java
git commit -m "test: prove TestWorkflowEnvironment/WorkflowClient are fresh per test method"
```

---

### Task 7: Full suite verification, and a quick look at the disabled tests

**Files:**
- Investigate only (no guaranteed changes): `test-extension/deployment/src/test/java/io/quarkiverse/temporal/test/deployment/StartWorkersEnabledTest.java`, `StartWorkersDisabledTest.java`

**Interfaces:** none - this task is verification, not new code.

- [x] **Step 1: Run the full reactor test suite**

Run: `mvn -q verify`
Expected: BUILD SUCCESS across `extension`, `test-extension`, and `integration-tests` - including the pre-existing `CDIActivityIT`, `MoneyTransferIT`, `ContextPropagatorCdiIT`, `DataConverterCdiIT` (none of which explicitly close their environment, so they must keep working unchanged under the new fresh-per-test behavior).

- [x] **Step 2: Look at why `StartWorkersEnabledTest`/`StartWorkersDisabledTest` are `@Disabled`**

These two tests (in `test-extension/deployment`) are `QuarkusUnitTest`-based and were disabled in commit `700eeff` ("custom client") with no explanation. Read them, try removing `@Disabled` locally, and run:

Run: `mvn -q -pl test-extension/deployment -am test -Dtest=StartWorkersEnabledTest,StartWorkersDisabledTest`

If they pass cleanly after this change, remove the `@Disabled` annotations and commit that as a small separate cleanup. If they still fail for a reason unrelated to this fix, leave them disabled - this is a nice-to-have, not a requirement of this plan.
